### PR TITLE
feat: add public endpoint to validate certificate by access_key

### DIFF
--- a/api_certify/repositories/certificate_repository.py
+++ b/api_certify/repositories/certificate_repository.py
@@ -126,6 +126,13 @@ class CertificateRepository:
 
         return [CertificateInDb(**doc) for doc in docs]
 
+    async def find_by_access_key(self, access_key: str) -> dict | None:
+        doc = await self.certificate_collection.find_one({
+            "access_key": access_key,
+            "status": {"$in": ["available", "emitted"]},
+        })
+        return doc
+
     async def get_certificate(self, certificate_id: str) -> CertificateInDb:
         existingCertificate = await self.certificate_collection.find_one(
             {"user_id": certificate_id}

--- a/api_certify/routes/v1/certificate_routes.py
+++ b/api_certify/routes/v1/certificate_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 
-from api_certify.schemas.responses import SucessResponse
+from api_certify.schemas.responses import SucessResponse, CertificateValidationResponse
 from api_certify.models.certificate_model import (
     CreateCertificate,
 )
@@ -8,6 +8,22 @@ from api_certify.service.certificate_service import CertificateService
 from api_certify.dependencies import get_certificate_service
 
 certificate_routes = APIRouter(prefix="/certificate", tags=["Certificates"])
+
+
+@certificate_routes.get("/validate/{access_key}", response_model=SucessResponse, status_code=200)
+async def validate_certificate(
+    access_key: str,
+    service: CertificateService = Depends(get_certificate_service),
+):
+    try:
+        result = await service.validate_certificate(access_key)
+        return SucessResponse(
+            success=True,
+            message="Certificado válido.",
+            data=result.model_dump(),
+        )
+    except Exception as err:
+        raise HTTPException(status_code=404, detail=str(err))
 
 
 @certificate_routes.post("/{user_id}", response_model=SucessResponse, status_code=201)

--- a/api_certify/schemas/responses.py
+++ b/api_certify/schemas/responses.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 from typing import Optional, Any
+from datetime import datetime
 
 
 class BaseResponse(BaseModel):
@@ -14,3 +15,12 @@ class SucessResponse(BaseResponse):
 
 class ErrorResponse(BaseResponse):
     error_code: Optional[str] = None
+
+
+class CertificateValidationResponse(BaseModel):
+    participant_name: str
+    event_name: str
+    workload: str
+    issued_at: Optional[datetime] = None
+    event_start: Optional[datetime] = None
+    event_end: Optional[datetime] = None

--- a/api_certify/service/certificate_service.py
+++ b/api_certify/service/certificate_service.py
@@ -3,6 +3,7 @@ from api_certify.models.certificate_model import (
     CertificateInDb,
     CreateCertificate,
 )
+from api_certify.schemas.responses import CertificateValidationResponse
 from api_certify.repositories.auth_repository import AuthRepository
 
 class CertificateService:
@@ -39,3 +40,16 @@ class CertificateService:
         response = await self.certificate_repository.get_certificate(certificate_id)
         print(certificate_id)
         return response
+
+    async def validate_certificate(self, access_key: str) -> CertificateValidationResponse:
+        doc = await self.certificate_repository.find_by_access_key(access_key)
+        if not doc:
+            raise Exception("Certificado não encontrado ou código inválido.")
+        return CertificateValidationResponse(
+            participant_name=doc["participant_name"],
+            event_name=doc["event_name"],
+            workload=doc["workload"],
+            issued_at=doc.get("issued_at"),
+            event_start=doc.get("event_start"),
+            event_end=doc.get("event_end"),
+        )

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,7 +18,7 @@ version = "3.7.1"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "anyio-3.7.1-py3-none-any.whl", hash = "sha256:91dee416e570e92c64041bd18b900d1d6fa78dff7048769ce5ac5ddad004fbb5"},
     {file = "anyio-3.7.1.tar.gz", hash = "sha256:44a3c9aba0f5defa43261a8b3efb97891f2bd7d804e0e1f56419befa1adfc780"},
@@ -39,7 +39,7 @@ version = "2.1.0"
 description = "Programmatic startup/shutdown of ASGI apps."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "asgi-lifespan-2.1.0.tar.gz", hash = "sha256:5e2effaf0bfe39829cf2d64e7ecc47c7d86d676a6599f7afba378c31f5e3a308"},
     {file = "asgi_lifespan-2.1.0-py3-none-any.whl", hash = "sha256:ed840706680e28428c01e14afb3875d7d76d3206f3d5b2f2294e059b5c23804f"},
@@ -89,7 +89,7 @@ version = "2026.2.25"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa"},
     {file = "certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"},
@@ -416,7 +416,7 @@ version = "2.7.0"
 description = "DNS toolkit"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86"},
     {file = "dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1"},
@@ -508,38 +508,10 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
-]
-
-[[package]]
-name = "h2"
-version = "4.3.0"
-description = "Pure-Python HTTP/2 protocol implementation"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"},
-    {file = "h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1"},
-]
-
-[package.dependencies]
-hpack = ">=4.1,<5"
-hyperframe = ">=6.1,<7"
-
-[[package]]
-name = "hpack"
-version = "4.1.0"
-description = "Pure-Python HPACK header encoding"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"},
-    {file = "hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"},
 ]
 
 [[package]]
@@ -548,7 +520,7 @@ version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
     {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
@@ -623,7 +595,7 @@ version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
@@ -632,7 +604,6 @@ files = [
 [package.dependencies]
 anyio = "*"
 certifi = "*"
-h2 = {version = ">=3,<5", optional = true, markers = "extra == \"http2\""}
 httpcore = "==1.*"
 idna = "*"
 
@@ -644,24 +615,12 @@ socks = ["socksio (==1.*)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
-name = "hyperframe"
-version = "6.1.0"
-description = "Pure-Python HTTP/2 framing"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"},
-    {file = "hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08"},
-]
-
-[[package]]
 name = "idna"
 version = "3.11"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
     {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
@@ -709,7 +668,7 @@ version = "0.0.36"
 description = "Library for mocking AsyncIOMotorClient built on top of mongomock."
 optional = false
 python-versions = "<4.0,>=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "mongomock_motor-0.0.36-py3-none-any.whl", hash = "sha256:3ecb7949662b8986ff9c267fa0b1402b5b75a6afd57f03850cd6e13a067e3691"},
     {file = "mongomock_motor-0.0.36.tar.gz", hash = "sha256:3cf62352ece5af2f02e04d2f252393f88b5fe0487997da00584020cee4b8efba"},
@@ -725,7 +684,7 @@ version = "3.3.2"
 description = "Non-blocking MongoDB driver for Tornado or asyncio"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "motor-3.3.2-py3-none-any.whl", hash = "sha256:6fe7e6f0c4f430b9e030b9d22549b732f7c2226af3ab71ecc309e4a1b7d19953"},
     {file = "motor-3.3.2.tar.gz", hash = "sha256:d2fc38de15f1c8058f389c1a44a4d4105c0405c48c061cd492a654496f7bc26a"},
@@ -1055,7 +1014,7 @@ version = "4.5.0"
 description = "Python driver for MongoDB <http://www.mongodb.org>"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "pymongo-4.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2d4fa1b01fa7e5b7bb8d312e3542e211b320eb7a4e3d8dc884327039d93cb9e0"},
     {file = "pymongo-4.5.0-cp310-cp310-manylinux1_i686.whl", hash = "sha256:dfcd2b9f510411de615ccedd47462dae80e82fdc09fe9ab0f0f32f11cf57eeb5"},
@@ -1442,7 +1401,7 @@ version = "1.3.1"
 description = "Sniff out which async library your code is running under"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
@@ -1859,4 +1818,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "9d17a5ee829aa260863a257c311e10a632406ee1f377dfe79c70224bbb21f0bd"
+content-hash = "f3a1957aee87e627ecef3afeef07425d2ed03fff8a416c75834a590c33d2496d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ motor-types = "^1.0.0b4"
 
 pydantic = { extras = ["email"], version = "^2.12.2" }
 
-python-jose = { extras = ["cryptography"], version = "^3.5.0" }
+python-jose = {extras = ["cryptography"], version = "^3.5.0"}
 passlib = { extras = ["bcrypt"], version = "^1.7.4" }
 bcrypt = "4.0.1"
 


### PR DESCRIPTION
## Implementação: Endpoint de Validação Pública de Certificado

**Endpoint:** `GET /api/v1/certificate/validate/{access_key}`

### O que foi feito

Implementada a rota pública de consulta e validação de certificados, permitindo que empresas e recrutadores confirmem a autenticidade de um certificado a partir da sua chave de acesso única.

### Arquivos modificados

- `schemas/responses.py` — Criado schema CertificateValidationResponse (Pydantic)
- `repositories/certificate_repository.py` — Adicionado método find_by_access_key
- `service/certificate_service.py` — Adicionado método validate_certificate
- `routes/v1/certificate_routes.py` — Adicionado endpoint GET /validate/{access_key}

### Critérios atendidos

- ✅ Busca por access_key via Path Parameter (case-sensitive)
- ✅ Retorno 200 com: nome do aluno, nome do evento, carga horária, data de emissão e datas de realização
- ✅ Retorno 404 com mensagem: "Certificado não encontrado ou código inválido."
- ✅ Rota pública — não exige header Authorization / Token JWT
- ✅ Valida apenas certificados com status "available" ou "emitted"
- ✅ Arquitetura em camadas: Route → Service → Repository
- ✅ Resposta modelada com Pydantic (CertificateValidationResponse)
