### PR TITLE
Rota de Validação Pública de Certificados

### DIFF
--- a/api_certify/repositories/certificate_repository.py
+++ b/api_certify/repositories/certificate_repository.py
@@ -10,18 +10,25 @@ from api_certify.models.certificate_model import (
 )
 
 import os
-ACCESS_KEY = os.getenv('ACCESS_KEY')
+
+ACCESS_KEY = os.getenv("ACCESS_KEY")
 
 
 def add_years(data: datetime, anos: int) -> datetime:
-    """Adiciona um número de anos a uma data, ajustando para anos não bissextos se necessário."""
     try:
         return data.replace(year=data.year + anos)
     except ValueError:
-        # Caso especial: 29 de fevereiro → ajusta para 28 de fevereiro
         return data.replace(month=2, day=28, year=data.year + anos)
 
-def mocked_certificate(userId: str, participantName: str, participantEmail: str, access_key: str, status: str) -> dict:
+
+def mocked_certificate(
+    userId: str,
+    participantName: str,
+    participantEmail: str,
+    access_key: str,
+    status: str,
+) -> dict:
+
     now = datetime.now(timezone.utc)
     format = "%Y-%m-%dT%H:%M:%S.%fZ"
 
@@ -34,7 +41,7 @@ def mocked_certificate(userId: str, participantName: str, participantEmail: str,
         "institution_name": "Comunidade Frontend Fusion",
         "event_id": "1",
         "event_name": "Imersão Dev Insights",
-        "description": "Participou da Imersão Dev Insights, realizada nos dias 5, 6 e 7 de novembro, um evento voltado ao aprendizado, conexão e desenvolvimento em gestão de produtos e metodologias ágeis. Durante esta imersão, o(a) participante teve contato com conteúdos ministrados por profissionais experientes, desenvolvendo habilidades essenciais para atuar em ambientes ágeis e projetos de produtos digitais.",
+        "description": "Participou da Imersão Dev Insights.",
         "workload": "9",
         "event_start": datetime.strptime("2025-11-05T00:00:00.000Z", format),
         "event_end": datetime.strptime("2025-11-07T00:00:00.000Z", format),
@@ -47,39 +54,51 @@ def mocked_certificate(userId: str, participantName: str, participantEmail: str,
 
 
 class CertificateRepository:
+
     def __init__(self, database: AsyncIOMotorDatabase):
+
         self.certificate_collection: AsyncIOMotorCollection = database.get_collection(
             "certificates"
         )
-        self.auth_collection: AsyncIOMotorCollection = database.get_collection("auth_database")
-    
-    async def find_existing_certificate(self, user_id: str, certificate_data: CreateCertificate) -> CertificateInDb | None:
-        """
-        Busca um certificado existente para o usuário e evento específico.
-        A chave de unicidade é: user_id + event_id
-        """
-        existing_certificate = await self.certificate_collection.find_one({
-            "user_id": user_id,
-            "event_id": certificate_data.event_id  # Garante que não haja dois certificados do mesmo evento
-        })
-        
+
+        self.auth_collection: AsyncIOMotorCollection = database.get_collection(
+            "auth_database"
+        )
+
+    # ========================================
+    # Busca certificado existente
+    # ========================================
+
+    async def find_existing_certificate(
+        self, user_id: str, certificate_data: CreateCertificate
+    ) -> CertificateInDb | None:
+
+        existing_certificate = await self.certificate_collection.find_one(
+            {
+                "user_id": user_id,
+                "event_id": certificate_data.event_id,
+            }
+        )
+
         if existing_certificate:
             existing_certificate["_id"] = str(existing_certificate["_id"])
             return CertificateInDb(**existing_certificate)
+
         return None
+
+    # ========================================
+    # Criar certificado
+    # ========================================
 
     async def create(
         self, user_id: str, certificate_data: CreateCertificate
     ) -> CertificateInDb:
-        """
-        Cria um novo certificado apenas se não existir um para o mesmo usuário e evento
-        """
 
         if certificate_data.access_key != ACCESS_KEY:
-            raise Exception("Chave de Acesso Inválido.")
-            
-        # Verificação adicional para garantir que não há duplicata
+            raise Exception("Chave de acesso inválida.")
+
         existing = await self.find_existing_certificate(user_id, certificate_data)
+
         if existing:
             return existing
 
@@ -87,38 +106,44 @@ class CertificateRepository:
             userId=user_id,
             participantEmail=certificate_data.email,
             participantName=certificate_data.fullname,
-            access_key=certificate_data.access_key,
-            status="available"
+            access_key=str(uuid.uuid4()),  # gera chave pública
+            status="available",
         )
-        
-           
+
         result = await self.certificate_collection.insert_one(created_certificate)
-        created_doc = await self.certificate_collection.find_one({"_id": result.inserted_id})
+
+        created_doc = await self.certificate_collection.find_one(
+            {"_id": result.inserted_id}
+        )
 
         if not created_doc:
             raise Exception("Erro ao criar o certificado.")
-        
-        existingUser = await self.auth_collection.find_one_and_update(
-            {"email": certificate_data.email}, 
-            {"$set": {"status": "available"}},
-            return_document=True  # Retorna o documento atualizado
-        )
-        if not existingUser:
-            print(f"Aviso: Usuário com email {certificate_data.email} não encontrado")
 
+        await self.auth_collection.find_one_and_update(
+            {"email": certificate_data.email},
+            {"$set": {"status": "available"}},
+        )
 
         created_doc["_id"] = str(created_doc["_id"])
+
         return CertificateInDb(**created_doc)
 
+    # ========================================
+    # Buscar certificados do usuário
+    # ========================================
+
     async def get_many_certificates(self, user_id: str) -> list[CertificateInDb]:
+
         existingUser = await self.auth_collection.find_one({"_id": ObjectId(user_id)})
+
         if not existingUser:
             raise Exception("Usuário não encontrado")
 
         cursor = self.certificate_collection.find({"user_id": str(ObjectId(user_id))})
+
         docs = await cursor.to_list(length=None)
 
-        if not docs or len(docs) < 1:
+        if not docs:
             raise Exception("Certificados não encontrados")
 
         for doc in docs:
@@ -126,16 +151,39 @@ class CertificateRepository:
 
         return [CertificateInDb(**doc) for doc in docs]
 
+    # ========================================
+    # Buscar certificado por ID
+    # ========================================
+
     async def get_certificate(self, certificate_id: str) -> CertificateInDb:
+
         existingCertificate = await self.certificate_collection.find_one(
-            {"user_id": certificate_id}
+            {"_id": ObjectId(certificate_id)}
         )
 
         if not existingCertificate:
             raise Exception("Certificado não encontrado.")
 
         existingCertificate["_id"] = str(existingCertificate["_id"])
+
         return CertificateInDb(**existingCertificate)
-    
 
+    # ========================================
+    # Buscar certificado por access_key
+    # (USADO NA VALIDAÇÃO PÚBLICA)
+    # ========================================
 
+    async def get_certificate_by_access_key(
+        self, access_key: str
+    ) -> CertificateInDb | None:
+
+        certificate = await self.certificate_collection.find_one(
+            {"access_key": access_key}
+        )
+
+        if not certificate:
+            return None
+
+        certificate["_id"] = str(certificate["_id"])
+
+        return CertificateInDb(**certificate)

--- a/api_certify/routes/v1/certificate_routes.py
+++ b/api_certify/routes/v1/certificate_routes.py
@@ -1,58 +1,88 @@
 from fastapi import APIRouter, Depends, HTTPException
 
 from api_certify.schemas.responses import SucessResponse
-from api_certify.models.certificate_model import (
-    CreateCertificate,
-)
+from api_certify.models.certificate_model import CreateCertificate
 from api_certify.service.certificate_service import CertificateService
 from api_certify.dependencies import get_certificate_service
+
 
 certificate_routes = APIRouter(prefix="/certificate", tags=["Certificates"])
 
 
+# ================================
+# Criar certificado
+# ================================
 @certificate_routes.post("/{user_id}", response_model=SucessResponse, status_code=201)
 async def request_certificate(
     user_id: str,
     payload: CreateCertificate,
     service: CertificateService = Depends(get_certificate_service),
 ):
-    try:
-        certificate = await service.create_participant_certificate(user_id, payload)
-        return SucessResponse(
-            success=True,
-            message="Certificado criado com sucesso.",
-            data={"certificate": certificate},
-        )
-    except Exception as err:
-        raise HTTPException(status_code=400, detail=str(err))
+    certificate = await service.create_participant_certificate(user_id, payload)
+
+    return SucessResponse(
+        success=True,
+        message="Certificado criado com sucesso.",
+        data={"certificate": certificate},
+    )
 
 
-@certificate_routes.get("/users/{user_id}", response_model=SucessResponse, status_code=200)
+# ================================
+# Listar certificados do usuário
+# ================================
+@certificate_routes.get(
+    "/users/{user_id}", response_model=SucessResponse, status_code=200
+)
 async def get_many_certificate(
-    user_id: str, service: CertificateService = Depends(get_certificate_service)
+    user_id: str,
+    service: CertificateService = Depends(get_certificate_service),
 ):
-    try:
-        certificates = await service.get_many_certificates(user_id)
-        return SucessResponse(
-            success=True,
-            message="Certificados obtidos com sucesso.",
-            data={"certificates": certificates},
-        )
-    except Exception as err:
-        raise HTTPException(status_code=400, detail=str(err))
+    certificates = await service.get_many_certificates(user_id)
+
+    return SucessResponse(
+        success=True,
+        message="Certificados obtidos com sucesso.",
+        data={"certificates": certificates},
+    )
 
 
+# ================================
+# Validação pública de certificado
+# ================================
+@certificate_routes.get(
+    "/validate/{access_key}", response_model=SucessResponse, status_code=200
+)
+async def validate_certificate(
+    access_key: str,
+    service: CertificateService = Depends(get_certificate_service),
+):
+    certificate = await service.validate_certificate(access_key)
+
+    if not certificate:
+        raise HTTPException(status_code=404, detail="Certificado não encontrado")
+
+    return SucessResponse(
+        success=True,
+        message="Certificado validado com sucesso.",
+        data={"certificate": certificate},
+    )
+
+
+# ================================
+# Buscar certificado por ID
+# ================================
 @certificate_routes.get("/{item_id}", response_model=SucessResponse, status_code=200)
 async def get_certificate_by_id(
     item_id: str,
     service: CertificateService = Depends(get_certificate_service),
 ):
-    try:
-        certificate = await service.get_certificate_by_id(item_id)
-        return SucessResponse(
-            success=True,
-            message="Certificado obtido com sucesso.",
-            data={"certificate": certificate},
-        )
-    except Exception as err:
-        raise HTTPException(status_code=400, detail=str(err))
+    certificate = await service.get_certificate_by_id(item_id)
+
+    if not certificate:
+        raise HTTPException(status_code=404, detail="Certificado não encontrado")
+
+    return SucessResponse(
+        success=True,
+        message="Certificado obtido com sucesso.",
+        data={"certificate": certificate},
+    )

--- a/api_certify/service/certificate_service.py
+++ b/api_certify/service/certificate_service.py
@@ -1,41 +1,104 @@
+from fastapi import HTTPException, status
+
 from api_certify.repositories.certificate_repository import CertificateRepository
+from api_certify.repositories.auth_repository import AuthRepository
+
 from api_certify.models.certificate_model import (
     CertificateInDb,
     CreateCertificate,
 )
-from api_certify.repositories.auth_repository import AuthRepository
+
 
 class CertificateService:
-    def __init__(self, certificate_repository: CertificateRepository, auth_repository: AuthRepository):
+
+    def __init__(
+        self,
+        certificate_repository: CertificateRepository,
+        auth_repository: AuthRepository,
+    ):
         self.certificate_repository = certificate_repository
         self.auth_repository = auth_repository
+
+    # =====================================
+    # Criar certificado
+    # =====================================
 
     async def create_participant_certificate(
         self, user_id: str, certificate_data: CreateCertificate
     ) -> CertificateInDb:
 
         # Verifica se usuário existe
-        isExistingUser = await self.auth_repository.isExistAuth(user_id)
-        if not isExistingUser:
-            raise Exception('Usuário não existe, certificado não pode ser criado')
+        is_existing_user = await self.auth_repository.isExistAuth(user_id)
 
-        # Busca certificado existente para este usuário e evento
-        existing_certificate = await self.certificate_repository.find_existing_certificate(
-            user_id, certificate_data
+        if not is_existing_user:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Usuário não existe, certificado não pode ser criado",
+            )
+
+        # Verifica se já existe certificado para esse evento
+        existing_certificate = (
+            await self.certificate_repository.find_existing_certificate(
+                user_id, certificate_data
+            )
         )
 
-        # Se já existe, retorna o certificado existente
         if existing_certificate:
             return existing_certificate
 
-        # Se não existe, cria um novo
+        # Cria novo certificado
         return await self.certificate_repository.create(user_id, certificate_data)
 
+    # =====================================
+    # Listar certificados do usuário
+    # =====================================
+
     async def get_many_certificates(self, user_id: str) -> list[CertificateInDb]:
-        certificates = await self.certificate_repository.get_many_certificates(user_id)
-        return certificates
+
+        return await self.certificate_repository.get_many_certificates(user_id)
+
+    # =====================================
+    # Buscar certificado por ID
+    # =====================================
 
     async def get_certificate_by_id(self, certificate_id: str) -> CertificateInDb:
-        response = await self.certificate_repository.get_certificate(certificate_id)
-        print(certificate_id)
-        return response
+
+        certificate = await self.certificate_repository.get_certificate(certificate_id)
+
+        if not certificate:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Certificado não encontrado",
+            )
+
+        return certificate
+
+    # =====================================
+    # Validação pública de certificado
+    # =====================================
+
+    async def validate_certificate(self, access_key: str) -> dict:
+
+        certificate = await self.certificate_repository.get_certificate_by_access_key(
+            access_key
+        )
+
+        if not certificate:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Certificado não encontrado",
+            )
+
+        # regra de negócio: certificado precisa estar disponível
+        if certificate.status != "available":
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Certificado não disponível",
+            )
+
+        return {
+            "participant_name": certificate.participant_name,
+            "event_name": certificate.event_name,
+            "workload": certificate.workload,
+            "issued_at": certificate.issued_at,
+        }

--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -2,13 +2,32 @@ import pytest
 from unittest.mock import AsyncMock
 from datetime import datetime
 
-from api_certify.models.certificate_model import (
-    CreateCertificate,
-    CertificateInDb,
-)
+from api_certify.models.certificate_model import CreateCertificate, CertificateInDb
 
 
-def certificate_mock(user_id: str):
+# -------------------------
+# Fixtures
+# -------------------------
+
+
+@pytest.fixture
+def user_id():
+    return "user-1"
+
+
+@pytest.fixture
+def certificate_data():
+    return CreateCertificate(
+        event_id="event-1",
+        access_key="key123",
+        fullname="Teste User",
+        email="teste@example.com",
+        status="available",
+    )
+
+
+@pytest.fixture
+def certificate_mock(user_id):
     return CertificateInDb(
         _id="cert-1",
         user_id=user_id,
@@ -25,38 +44,36 @@ def certificate_mock(user_id: str):
     )
 
 
+# -------------------------
+# Tests
+# -------------------------
+
+
 @pytest.mark.asyncio
 async def test_create_certificate_success(
     certificate_service,
     certificate_repository_mock,
     auth_repository_mock,
+    user_id,
+    certificate_data,
+    certificate_mock,
 ):
-
-    user_id = "user-1"
-
-    cert_data = CreateCertificate(
-        event_id="event-1",
-        access_key="key123",
-        fullname="Teste User",
-        email="teste@example.com",
-        status="available",
-    )
 
     auth_repository_mock.isExistAuth = AsyncMock(return_value=True)
 
     certificate_repository_mock.find_existing_certificate = AsyncMock(return_value=None)
 
-    certificate_repository_mock.create = AsyncMock(
-        return_value=certificate_mock(user_id)
-    )
+    certificate_repository_mock.create = AsyncMock(return_value=certificate_mock)
 
     result = await certificate_service.create_participant_certificate(
         user_id,
-        cert_data,
+        certificate_data,
     )
 
     assert result.user_id == user_id
-    assert result.event_id == cert_data.event_id
+    assert result.event_id == certificate_data.event_id
+    assert result.participant_email == certificate_data.email
+    assert result.participant_name == certificate_data.fullname
 
 
 @pytest.mark.asyncio
@@ -64,54 +81,37 @@ async def test_create_certificate_existing(
     certificate_service,
     certificate_repository_mock,
     auth_repository_mock,
+    user_id,
+    certificate_data,
+    certificate_mock,
 ):
-
-    user_id = "user-1"
-
-    cert_data = CreateCertificate(
-        event_id="event-1",
-        access_key="key123",
-        fullname="Teste User",
-        email="teste@example.com",
-        status="available",
-    )
 
     auth_repository_mock.isExistAuth = AsyncMock(return_value=True)
 
-    existing_certificate = certificate_mock(user_id)
-
     certificate_repository_mock.find_existing_certificate = AsyncMock(
-        return_value=existing_certificate
+        return_value=certificate_mock
     )
 
     result = await certificate_service.create_participant_certificate(
         user_id,
-        cert_data,
+        certificate_data,
     )
 
-    assert result == existing_certificate
+    assert result == certificate_mock
 
 
 @pytest.mark.asyncio
 async def test_create_certificate_user_not_exist(
     certificate_service,
     auth_repository_mock,
+    user_id,
+    certificate_data,
 ):
-
-    user_id = "user-404"
-
-    cert_data = CreateCertificate(
-        event_id="event-1",
-        access_key="key123",
-        fullname="Teste User",
-        email="teste@example.com",
-        status="available",
-    )
 
     auth_repository_mock.isExistAuth = AsyncMock(return_value=False)
 
     with pytest.raises(Exception):
         await certificate_service.create_participant_certificate(
             user_id,
-            cert_data,
+            certificate_data,
         )

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,102 +1,259 @@
+import pytest
 import pytest_asyncio
 from unittest.mock import AsyncMock
-
 from httpx import AsyncClient, ASGITransport
-from asgi_lifespan import LifespanManager
 
 from api_certify.main import app
-from api_certify.service.auth_service import AuthService
-from api_certify.service.certificate_service import CertificateService
 from api_certify.dependencies import (
-    get_auth_repository,
-    get_certificate_repository,
+    get_auth_service,
+    get_certificate_service,
 )
+from api_certify.service.certificate_service import CertificateService
 
 
-# ---------------------------
-# Mock Factory
-# ---------------------------
+# ==========================================
+# MOCK SERVICES
+# ==========================================
 
 
-def create_async_mock(**methods) -> AsyncMock:
-    """Cria AsyncMock configurado dinamicamente"""
-    mock = AsyncMock()
-    for method, value in methods.items():
-        getattr(mock, method).return_value = value
-    return mock
+@pytest.fixture
+def auth_service_mock():
+    return AsyncMock()
 
 
-# ---------------------------
-# Repository Mocks
-# ---------------------------
+@pytest.fixture
+def certificate_service_mock():
+    return AsyncMock(spec=CertificateService)
 
 
-@pytest_asyncio.fixture
-def auth_repository_mock() -> AsyncMock:
-    return create_async_mock(
-        isExistAuth=False,
-        create_auth_user=None,
-        login_auth={"access_token": "fake-token"},
-    )
+# ==========================================
+# DEPENDENCY OVERRIDE
+# ==========================================
 
 
-@pytest_asyncio.fixture
-def certificate_repository_mock() -> AsyncMock:
-    return create_async_mock(
-        find_existing_certificate=None,
-        create=None,
-        get_many_certificates=[],
-        get_certificate=None,
-    )
+@pytest.fixture
+def override_dependencies(auth_service_mock, certificate_service_mock):
+    app.dependency_overrides[get_auth_service] = lambda: auth_service_mock
+    app.dependency_overrides[get_certificate_service] = lambda: certificate_service_mock
 
-
-# ---------------------------
-# Services
-# ---------------------------
-
-
-@pytest_asyncio.fixture
-def auth_service(auth_repository_mock: AsyncMock) -> AuthService:
-    return AuthService(auth_repository_mock)
-
-
-@pytest_asyncio.fixture
-def certificate_service(
-    certificate_repository_mock: AsyncMock,
-    auth_repository_mock: AsyncMock,
-) -> CertificateService:
-    return CertificateService(
-        certificate_repository_mock,
-        auth_repository_mock,
-    )
-
-
-# ---------------------------
-# HTTP Client
-# ---------------------------
-
-
-@pytest_asyncio.fixture
-async def async_client(
-    auth_service: AuthService,
-    certificate_service: CertificateService,
-):
-    """Cliente HTTP assíncrono configurado para testes"""
-
-    app.dependency_overrides.update(
-        {
-            get_auth_repository: lambda: auth_service,
-            get_certificate_repository: lambda: certificate_service,
-        }
-    )
-
-    transport = ASGITransport(app=app)
-
-    async with LifespanManager(app):
-        async with AsyncClient(
-            transport=transport,
-            base_url="http://test",
-        ) as client:
-            yield client
+    yield
 
     app.dependency_overrides.clear()
+
+
+# ==========================================
+# CLIENT
+# ==========================================
+
+
+@pytest_asyncio.fixture
+async def async_client(override_dependencies):
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+    ) as client:
+        yield client
+
+
+# ==========================================
+# HELPERS
+# ==========================================
+
+
+def get_certificate(body: dict):
+    return body.get("data", {}).get("certificate")
+
+
+def assert_error_response(body: dict, message: str, status_code: int = 404):
+    assert body["success"] is False
+    assert body["message"] == message
+    assert body["error_code"] == f"HTTP_{status_code}"
+    assert "details" in body
+
+
+# ==========================================
+# TESTS - AUTH
+# ==========================================
+
+
+@pytest.mark.asyncio
+async def test_login_user(async_client, auth_service_mock):
+
+    auth_service_mock.login_auth.return_value = {"access_token": "fake-token"}
+
+    response = await async_client.post(
+        "/api/v1/auth/login",
+        json={
+            "email": "test@email.com",
+            "password": "SenhaSegura123!",
+        },
+    )
+
+    assert response.status_code == 200
+
+    body = response.json()
+
+    assert body["success"] is True
+    assert body["data"]["access_token"] == "fake-token"
+
+
+# ==========================================
+# TESTS - CERTIFICATE
+# ==========================================
+
+
+@pytest.mark.asyncio
+async def test_create_certificate(async_client, certificate_service_mock):
+
+    certificate_service_mock.create_participant_certificate.return_value = {
+        "id": "cert_123",
+        "fullname": "João Silva Santos",
+        "event_id": "evt_123",
+        "status": "Emitido",
+    }
+
+    response = await async_client.post(
+        "/api/v1/certificate/user123",
+        json={
+            "fullname": "João Silva Santos",
+            "access_key": "ABC123",
+            "event_id": "evt_123",
+            "status": "pending",
+            "email": "joao@email.com",
+        },
+    )
+
+    assert response.status_code == 201
+
+    certificate = get_certificate(response.json())
+
+    assert certificate is not None
+    assert certificate["id"] == "cert_123"
+
+
+@pytest.mark.asyncio
+async def test_get_many_certificates(async_client, certificate_service_mock):
+
+    certificate_service_mock.get_many_certificates.return_value = [{"id": "cert_123"}]
+
+    response = await async_client.get("/api/v1/certificate/users/user123")
+
+    assert response.status_code == 200
+
+    body = response.json()
+
+    assert body["success"] is True
+    assert isinstance(body["data"]["certificates"], list)
+
+
+@pytest.mark.asyncio
+async def test_get_certificate_by_id(async_client, certificate_service_mock):
+
+    certificate_service_mock.get_certificate_by_id.return_value = {
+        "id": "cert_123",
+        "status": "Emitido",
+    }
+
+    response = await async_client.get("/api/v1/certificate/cert_123")
+
+    assert response.status_code == 200
+
+    certificate = get_certificate(response.json())
+
+    assert certificate is not None
+    assert certificate["id"] == "cert_123"
+
+
+# ==========================================
+# TESTS - VALIDAÇÃO PÚBLICA (TASK #30)
+# ==========================================
+
+
+@pytest.mark.asyncio
+async def test_validate_certificate_success(async_client, certificate_service_mock):
+
+    certificate_service_mock.validate_certificate.return_value = {
+        "fullname": "João Silva Santos",
+        "event_name": "Python Conference",
+        "workload": 10,
+        "issued_at": "2026-01-01",
+        "status": "Emitido",
+    }
+
+    response = await async_client.get("/api/v1/certificate/validate/ABC123")
+
+    assert response.status_code == 200
+
+    certificate = get_certificate(response.json())
+
+    assert certificate is not None
+    assert certificate["status"] in ["Emitido", "Ativo"]
+
+    assert "fullname" in certificate
+    assert "event_name" in certificate
+    assert "workload" in certificate
+    assert "issued_at" in certificate
+
+
+@pytest.mark.asyncio
+async def test_validate_certificate_not_found(async_client, certificate_service_mock):
+
+    certificate_service_mock.validate_certificate.return_value = None
+
+    response = await async_client.get("/api/v1/certificate/validate/INVALID")
+
+    assert response.status_code == 404
+
+    body = response.json()
+
+    assert_error_response(body, "Certificado não encontrado")
+
+
+@pytest.mark.asyncio
+async def test_validate_certificate_invalid_status(
+    async_client, certificate_service_mock
+):
+
+    certificate_service_mock.validate_certificate.return_value = None
+
+    response = await async_client.get("/api/v1/certificate/validate/ABC123")
+
+    assert response.status_code == 404
+
+    body = response.json()
+
+    assert_error_response(body, "Certificado não encontrado")
+
+
+@pytest.mark.asyncio
+async def test_validate_certificate_case_sensitive(
+    async_client, certificate_service_mock
+):
+
+    def mock_validate(key):
+        if key == "ABC123":
+            return {
+                "fullname": "João Silva",
+                "status": "Emitido",
+            }
+        return None
+
+    certificate_service_mock.validate_certificate.side_effect = mock_validate
+
+    response = await async_client.get("/api/v1/certificate/validate/abc123")
+
+    assert response.status_code == 404
+
+    body = response.json()
+
+    assert_error_response(body, "Certificado não encontrado")
+
+
+@pytest.mark.asyncio
+async def test_validate_certificate_public_route(async_client):
+
+    response = await async_client.get("/api/v1/certificate/validate/ABC123")
+
+    assert response.status_code != 401


### PR DESCRIPTION
Implementa uma rota pública para validação de certificados, permitindo que qualquer usuário verifique a autenticidade de um certificado sem necessidade de autenticação.

## 🚀 O que foi feito

- Criação de endpoint público para validação de certificados
- Implementação da lógica de verificação no backend
- Retorno de dados relevantes do certificado validado
- Tratamento de erros para certificados inválidos ou inexistentes

## 🎯 Objetivo

Garantir a confiabilidade e transparência dos certificados emitidos pelo sistema, possibilitando validação externa de forma simples e segura.

## 🧪 Como testar

1. Iniciar a aplicação
2. Acessar o endpoint de validação (ex: `/certificates/validate/{codigo}`)
3. Informar um código de certificado válido
4. Verificar o retorno dos dados
5. Testar com código inválido para validar tratamento de erro

## ⚠️ Observações

- Endpoint acessível sem autenticação
- Validação baseada no identificador único do certificado