### PR TITLE
#78 feat: implement RBAC route protection middleware

### DIFF
--- a/api_certify/core/security.py
+++ b/api_certify/core/security.py
@@ -1,8 +1,9 @@
-from datetime import datetime, timedelta, timezone
-from jose import jwt, JWTError
-from passlib.context import CryptContext
 import os
+from datetime import datetime, timedelta, timezone
+
 from dotenv import load_dotenv
+from jose import JWTError, jwt
+from passlib.context import CryptContext
 
 load_dotenv()
 
@@ -28,7 +29,7 @@ class HashManager:
 
 
 def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
-    required_claims = ["sub", "email"]
+    required_claims = ["sub", "email", "role"]
 
     for claim in required_claims:
         if claim not in data:
@@ -39,7 +40,9 @@ def create_access_token(data: dict, expires_delta: timedelta | None = None) -> s
     if expires_delta:
         expire = datetime.now(timezone.utc) + expires_delta
     else:
-        expire = datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+        expire = datetime.now(timezone.utc) + timedelta(
+            minutes=ACCESS_TOKEN_EXPIRE_MINUTES
+        )
 
     to_encode.update({"exp": expire})
 

--- a/api_certify/dependencies.py
+++ b/api_certify/dependencies.py
@@ -1,13 +1,12 @@
 from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from api_certify.core.database.mongodb import db_mongo
 from api_certify.core.security import decode_access_token
-from api_certify.service.auth_service import AuthService
 from api_certify.repositories.auth_repository import AuthRepository
-from api_certify.service.certificate_service import CertificateService
 from api_certify.repositories.certificate_repository import CertificateRepository
-
+from api_certify.service.auth_service import AuthService
+from api_certify.service.certificate_service import CertificateService
 
 security_scheme = HTTPBearer()
 
@@ -28,6 +27,29 @@ async def get_current_user(
         )
 
     return payload
+
+
+def require_role(*allowed_roles: str):
+
+    async def role_checker(
+        current_user: dict = Depends(get_current_user),
+    ):
+
+        role = current_user.get("role")
+
+        # Admin possui acesso total
+        if role == "admin":
+            return current_user
+
+        if role not in allowed_roles:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Acesso negado. Permissão insuficiente para esta ação.",
+            )
+
+        return current_user
+
+    return role_checker
 
 
 # ---------- AUTH ----------

--- a/api_certify/models/auth_model.py
+++ b/api_certify/models/auth_model.py
@@ -1,34 +1,43 @@
-from pydantic import BaseModel, Field, EmailStr, ConfigDict
 from datetime import datetime
-from typing import Optional
 from enum import Enum
+from typing import Optional
 
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 FULLNAME_MAX = 100
 FULLNAME_MIN = 6
 PASSWORD_MAX = 100
 PASSWORD_MIN = 8
 
-DESC_FULLNAME = 'Nome completo do usuário para identificação. Deve conter nome e sobrenome'
-DESC_EMAIL = 'Endereço de email válido utilizado para login e comunicação'
-DESC_PASSWORD = 'Senha de acesso segura. Deve conter letras, números e caracteres especiais'
-DESC_ROLE = 'Nível de acesso do usuário no sistema. Define permissões e funcionalidades disponíveis'
-DESC_STATUS = 'Status do usuário no sistema. Indica se possui certificado disponível ou outros estados'
-DESC_CREATED_AT = 'Data e hora de criação do registro no sistema. Preenchido automaticamente'
-DESC_UPDATED_AT = 'Data e hora da última atualização do registro. Atualizado automaticamente'
-DESC_USER_ID = 'Identificador único do usuário no banco de dados (MongoDB ObjectId)'
+DESC_FULLNAME = (
+    "Nome completo do usuário para identificação. Deve conter nome e sobrenome"
+)
+DESC_EMAIL = "Endereço de email válido utilizado para login e comunicação"
+DESC_PASSWORD = (
+    "Senha de acesso segura. Deve conter letras, números e caracteres especiais"
+)
+DESC_ROLE = "Nível de acesso do usuário no sistema. Define permissões e funcionalidades disponíveis"
+DESC_STATUS = "Status do usuário no sistema. Indica se possui certificado disponível ou outros estados"
+DESC_CREATED_AT = (
+    "Data e hora de criação do registro no sistema. Preenchido automaticamente"
+)
+DESC_UPDATED_AT = (
+    "Data e hora da última atualização do registro. Atualizado automaticamente"
+)
+DESC_USER_ID = "Identificador único do usuário no banco de dados (MongoDB ObjectId)"
 
-EXAMPLE_FULLNAME = 'João Silva Santos'
-EXAMPLE_EMAIL = 'usuario@empresa.com'
-EXAMPLE_PASSWORD = 'SenhaSegura123!'
-EXAMPLE_USER_ID = '507f1f77bcf86cd799439011'
-EXAMPLE_DATETIME = '2024-01-15T10:30:00.000Z'
-EXAMPLE_STATUS = 'available'
+EXAMPLE_FULLNAME = "João Silva Santos"
+EXAMPLE_EMAIL = "usuario@empresa.com"
+EXAMPLE_PASSWORD = "SenhaSegura123!"
+EXAMPLE_USER_ID = "507f1f77bcf86cd799439011"
+EXAMPLE_DATETIME = "2024-01-15T10:30:00.000Z"
+EXAMPLE_STATUS = "available"
 
 
 class Role(str, Enum):
-    ADMIN = 'admin'
-    USER = 'user'
+    ADMIN = "admin"
+    EMPRESA = "empresa"
+    USER = "user"
 
 
 class AuthUser(BaseModel):
@@ -37,67 +46,40 @@ class AuthUser(BaseModel):
         max_length=FULLNAME_MAX,
         min_length=FULLNAME_MIN,
         description=DESC_FULLNAME,
-        example=EXAMPLE_FULLNAME
+        example=EXAMPLE_FULLNAME,
     )
-    email: EmailStr = Field(
-        ..., 
-        description=DESC_EMAIL,
-        example=EXAMPLE_EMAIL
-    )
+    email: EmailStr = Field(..., description=DESC_EMAIL, example=EXAMPLE_EMAIL)
     password: str = Field(
         ...,
         max_length=PASSWORD_MAX,
         min_length=PASSWORD_MIN,
         description=DESC_PASSWORD,
-        example=EXAMPLE_PASSWORD
+        example=EXAMPLE_PASSWORD,
     )
-    role: Role = Field(
-        ..., 
-        description=DESC_ROLE,
-        example=Role.USER
-    )
-    status: Optional[str] = Field(
-        None,
-        description=DESC_STATUS,
-        example=EXAMPLE_STATUS
-    )
-    created_at: Optional[datetime] = Field(
-        None,
-        description=DESC_CREATED_AT
-    )
-    updated_at: Optional[datetime] = Field(
-        None,
-        description=DESC_UPDATED_AT
-    )
+    role: Role = Field(..., description=DESC_ROLE, example=Role.USER)
+    status: Optional[str] = Field(None, description=DESC_STATUS, example=EXAMPLE_STATUS)
+    created_at: Optional[datetime] = Field(None, description=DESC_CREATED_AT)
+    updated_at: Optional[datetime] = Field(None, description=DESC_UPDATED_AT)
 
 
 class AuthUserLogin(BaseModel):
-    email: EmailStr = Field(
-        ..., 
-        description=DESC_EMAIL,
-        example=EXAMPLE_EMAIL
-    )
+    email: EmailStr = Field(..., description=DESC_EMAIL, example=EXAMPLE_EMAIL)
     password: str = Field(
         ...,
         max_length=PASSWORD_MAX,
         min_length=PASSWORD_MIN,
         description=DESC_PASSWORD,
-        example=EXAMPLE_PASSWORD
+        example=EXAMPLE_PASSWORD,
     )
 
 
 class AuthUserInDb(AuthUser):
-    id: str = Field(
-        ..., 
-        alias='_id',
-        description=DESC_USER_ID,
-        example=EXAMPLE_USER_ID
-    )
+    id: str = Field(..., alias="_id", description=DESC_USER_ID, example=EXAMPLE_USER_ID)
     model_config = ConfigDict(use_enum_values=True, populate_by_name=True)
 
 
-DESC_PHONE = 'Número de celular do usuário'
-EXAMPLE_PHONE = '(85) 99124-8874'
+DESC_PHONE = "Número de celular do usuário"
+EXAMPLE_PHONE = "(85) 99124-8874"
 
 
 class UpdateUserSchema(BaseModel):
@@ -121,41 +103,20 @@ class UpdateUserSchema(BaseModel):
 
 
 class AuthUserReponse(BaseModel):
-    id: str = Field(
-        ..., 
-        alias='_id',
-        description=DESC_USER_ID,
-        example=EXAMPLE_USER_ID
-    )
+    id: str = Field(..., alias="_id", description=DESC_USER_ID, example=EXAMPLE_USER_ID)
     fullname: str = Field(
         ...,
         max_length=FULLNAME_MAX,
         min_length=FULLNAME_MIN,
         description=DESC_FULLNAME,
-        example=EXAMPLE_FULLNAME
+        example=EXAMPLE_FULLNAME,
     )
-    email: EmailStr = Field(
-        ..., 
-        description=DESC_EMAIL,
-        example=EXAMPLE_EMAIL
-    )
-    role: Role = Field(
-        ..., 
-        description=DESC_ROLE,
-        example=Role.USER
-    )
-    status: Optional[str] = Field(
-        None,
-        description=DESC_STATUS,
-        example=EXAMPLE_STATUS
-    )
+    email: EmailStr = Field(..., description=DESC_EMAIL, example=EXAMPLE_EMAIL)
+    role: Role = Field(..., description=DESC_ROLE, example=Role.USER)
+    status: Optional[str] = Field(None, description=DESC_STATUS, example=EXAMPLE_STATUS)
     created_at: Optional[datetime] = Field(
-        None,
-        description=DESC_CREATED_AT,
-        example=EXAMPLE_DATETIME
+        None, description=DESC_CREATED_AT, example=EXAMPLE_DATETIME
     )
     updated_at: Optional[datetime] = Field(
-        None,
-        description=DESC_UPDATED_AT,
-        example=EXAMPLE_DATETIME
+        None, description=DESC_UPDATED_AT, example=EXAMPLE_DATETIME
     )

--- a/api_certify/routes/v1/certificate_routes.py
+++ b/api_certify/routes/v1/certificate_routes.py
@@ -1,6 +1,10 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from api_certify.dependencies import get_certificate_service, get_current_user
+from api_certify.dependencies import (
+    get_certificate_service,
+    get_current_user,
+    require_role,
+)
 from api_certify.models.certificate_model import CreateCertificate
 from api_certify.schemas.responses import SucessResponse
 from api_certify.service.certificate_service import CertificateService
@@ -44,7 +48,7 @@ async def request_certificate(
     user_id: str,
     payload: CreateCertificate,
     service: CertificateService = Depends(get_certificate_service),
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_role("empresa")),
 ):
     certificate = await service.create_participant_certificate(user_id, payload)
 
@@ -79,6 +83,15 @@ async def get_many_certificate(
     service: CertificateService = Depends(get_certificate_service),
     current_user: dict = Depends(get_current_user),
 ):
+    role = current_user.get("role")
+    token_user_id = current_user.get("sub")
+
+    if role == "user" and token_user_id != user_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Acesso negado. Permissão insuficiente para esta ação.",
+        )
+
     certificates = await service.get_many_certificates(
         user_id=user_id,
         page=page,

--- a/api_certify/service/auth_service.py
+++ b/api_certify/service/auth_service.py
@@ -1,12 +1,13 @@
-from api_certify.repositories.auth_repository import AuthRepository
+from fastapi import HTTPException, status
+
+from api_certify.core.security import create_access_token
 from api_certify.models.auth_model import (
     AuthUser,
     AuthUserLogin,
     AuthUserReponse,
     UpdateUserSchema,
 )
-from api_certify.core.security import create_access_token
-from fastapi import HTTPException, status
+from api_certify.repositories.auth_repository import AuthRepository
 
 
 class AuthService:
@@ -31,6 +32,7 @@ class AuthService:
             {
                 "sub": str(user.id),
                 "email": user.email,
+                "role": user.role,
             }
         )
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
 
@@ -10,12 +11,12 @@ from api_certify.dependencies import (
     get_certificate_repository,
     get_certificate_service,
     get_current_user,
+    require_role,
 )
-
-from api_certify.service.auth_service import AuthService
-from api_certify.service.certificate_service import CertificateService
 from api_certify.repositories.auth_repository import AuthRepository
 from api_certify.repositories.certificate_repository import CertificateRepository
+from api_certify.service.auth_service import AuthService
+from api_certify.service.certificate_service import CertificateService
 
 
 @pytest.fixture
@@ -70,7 +71,13 @@ def test_get_certificate_service():
 
 @pytest.mark.asyncio
 async def test_get_current_user_valid_token():
-    token = create_access_token({"sub": "123", "email": "user@test.com"})
+    token = create_access_token(
+        {
+            "sub": "123",
+            "email": "user@test.com",
+            "role": "user",
+        }
+    )
     credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
 
     user = await get_current_user(credentials)
@@ -87,3 +94,55 @@ async def test_get_current_user_invalid_token():
         await get_current_user(credentials)
 
     assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_require_role_allows_empresa():
+
+    checker = require_role("empresa")
+
+    current_user = {
+        "sub": "123",
+        "email": "empresa@test.com",
+        "role": "empresa",
+    }
+
+    result = await checker(current_user=current_user)
+
+    assert result == current_user
+
+
+@pytest.mark.asyncio
+async def test_require_role_allows_admin():
+
+    checker = require_role("empresa")
+
+    current_user = {
+        "sub": "123",
+        "email": "admin@test.com",
+        "role": "admin",
+    }
+
+    result = await checker(current_user=current_user)
+
+    assert result == current_user
+
+
+@pytest.mark.asyncio
+async def test_require_role_denies_user():
+
+    checker = require_role("empresa")
+
+    current_user = {
+        "sub": "123",
+        "email": "user@test.com",
+        "role": "user",
+    }
+
+    with pytest.raises(HTTPException) as exc_info:
+        await checker(current_user=current_user)
+
+    assert exc_info.value.status_code == 403
+    assert (
+        exc_info.value.detail == "Acesso negado. Permissão insuficiente para esta ação."
+    )

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -30,12 +30,14 @@ def certificate_service_mock():
 
 @pytest.fixture
 def fake_current_user():
-    return {"sub": "user123", "email": "test@email.com"}
+    return {"sub": "user123", "email": "test@email.com", "role": "user"}
 
 
 @pytest.fixture
 def auth_headers():
-    token = create_access_token({"sub": "user123", "email": "test@email.com"})
+    token = create_access_token(
+        {"sub": "user123", "email": "test@email.com", "role": "user"}
+    )
     return {"Authorization": f"Bearer {token}"}
 
 
@@ -123,7 +125,9 @@ async def test_login_user(async_client, auth_service_mock):
 
 
 @pytest.mark.asyncio
-async def test_create_certificate(async_client, certificate_service_mock, auth_headers):
+async def test_create_certificate(
+    company_client, certificate_service_mock, company_headers
+):
 
     certificate_service_mock.create_participant_certificate.return_value = {
         "id": "cert_123",
@@ -132,7 +136,7 @@ async def test_create_certificate(async_client, certificate_service_mock, auth_h
         "status": "available",
     }
 
-    response = await async_client.post(
+    response = await company_client.post(
         "/api/v1/certificate/user123",
         json={
             "fullname": "João Silva Santos",
@@ -141,7 +145,7 @@ async def test_create_certificate(async_client, certificate_service_mock, auth_h
             "status": "pending",
             "email": "joao@email.com",
         },
-        headers=auth_headers,
+        headers=company_headers,
     )
 
     assert response.status_code == 201
@@ -409,3 +413,53 @@ async def test_update_user_without_token(async_client_no_auth):
     )
 
     assert response.status_code == 403
+
+
+@pytest.fixture
+def fake_company_user():
+    return {
+        "sub": "company123",
+        "email": "empresa@test.com",
+        "role": "empresa",
+    }
+
+
+@pytest.fixture
+def company_headers():
+    token = create_access_token(
+        {
+            "sub": "company123",
+            "email": "empresa@test.com",
+            "role": "empresa",
+        }
+    )
+
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def override_company_dependencies(
+    auth_service_mock,
+    certificate_service_mock,
+    fake_company_user,
+):
+    app.dependency_overrides[get_auth_service] = lambda: auth_service_mock
+    app.dependency_overrides[get_certificate_service] = lambda: certificate_service_mock
+    app.dependency_overrides[get_current_user] = lambda: fake_company_user
+
+    yield
+
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def company_client(
+    override_company_dependencies,
+):
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+    ) as client:
+        yield client

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,10 +1,18 @@
-import pytest
 from datetime import timedelta
+
+import pytest
+
 from api_certify.core.security import (
+    HashManager,
     create_access_token,
     decode_access_token,
-    HashManager,
 )
+
+JWT_PAYLOAD = {
+    "sub": "123",
+    "email": "user@test.com",
+    "role": "user",
+}
 
 
 # ==========================================
@@ -13,7 +21,7 @@ from api_certify.core.security import (
 
 
 def test_create_token():
-    token = create_access_token({"sub": "user@test.com", "email": "user@test.com"})
+    token = create_access_token(JWT_PAYLOAD)
 
     assert isinstance(token, str)
     assert len(token) > 10
@@ -21,19 +29,40 @@ def test_create_token():
 
 def test_create_token_missing_sub():
     with pytest.raises(ValueError, match="Claim obrigatória ausente: sub"):
-        create_access_token({"email": "user@test.com"})
+        create_access_token(
+            {
+                "email": "user@test.com",
+                "role": "user",
+            }
+        )
 
 
 def test_create_token_missing_email():
     with pytest.raises(ValueError, match="Claim obrigatória ausente: email"):
-        create_access_token({"sub": "123"})
+        create_access_token(
+            {
+                "sub": "123",
+                "role": "user",
+            }
+        )
+
+
+def test_create_token_missing_role():
+    with pytest.raises(ValueError, match="Claim obrigatória ausente: role"):
+        create_access_token(
+            {
+                "sub": "123",
+                "email": "user@test.com",
+            }
+        )
 
 
 def test_create_token_custom_expiration():
     token = create_access_token(
-        {"sub": "123", "email": "user@test.com"},
+        JWT_PAYLOAD,
         expires_delta=timedelta(minutes=5),
     )
+
     assert isinstance(token, str)
 
 
@@ -43,19 +72,21 @@ def test_create_token_custom_expiration():
 
 
 def test_decode_valid_token():
-    token = create_access_token({"sub": "123", "email": "user@test.com"})
+    token = create_access_token(JWT_PAYLOAD)
     payload = decode_access_token(token)
 
     assert payload is not None
-    assert payload["sub"] == "123"
-    assert payload["email"] == "user@test.com"
+    assert payload["sub"] == JWT_PAYLOAD["sub"]
+    assert payload["email"] == JWT_PAYLOAD["email"]
+    assert payload["role"] == JWT_PAYLOAD["role"]
 
 
 def test_decode_expired_token():
     token = create_access_token(
-        {"sub": "123", "email": "user@test.com"},
+        JWT_PAYLOAD,
         expires_delta=timedelta(seconds=-1),
     )
+
     payload = decode_access_token(token)
 
     assert payload is None
@@ -80,14 +111,13 @@ def test_hash_password():
 
 
 def test_verify_password_correct():
-    hashed = HashManager.hash_password("SenhaSegura123!")
-    result = HashManager.verify_password("SenhaSegura123!", hashed)
+    password = "SenhaSegura123!"
+    hashed = HashManager.hash_password(password)
 
-    assert result is True
+    assert HashManager.verify_password(password, hashed) is True
 
 
 def test_verify_password_wrong():
     hashed = HashManager.hash_password("SenhaSegura123!")
-    result = HashManager.verify_password("SenhaErrada", hashed)
 
-    assert result is False
+    assert HashManager.verify_password("SenhaErrada", hashed) is False


### PR DESCRIPTION
https://tree.taiga.io/project/laridurao-liga-da-justica/task/78

### Entrega Realizada - Task #78

Foi implementado o controle de acesso baseado em papéis (RBAC) utilizando o campo `role` presente no JWT, sem necessidade de consulta adicional ao banco de dados para validação de permissões.

#### Implementações realizadas

* Criação da dependency reutilizável `require_role(role: str)`.
* Inclusão e validação do campo `role` no payload do JWT.
* Ajuste das dependências de autenticação para extração do papel do usuário diretamente do token.
* Proteção da rota:

  * `POST /certificate/{user_id}` → acesso permitido apenas para `empresa` e `admin`.
* Restrição de acesso na rota:

  * `GET /certificate/users/{user_id}` → usuários com role `user` podem acessar apenas os próprios certificados.
* Mantida a regra da rota:

  * `PUT /auth/{user_id}` → qualquer usuário autenticado pode atualizar apenas os próprios dados.
* Mantida a rota pública:

  * `GET /certificate/validate/{access_key}` → sem necessidade de autenticação.

#### Regras de negócio atendidas

* Roles suportadas:

  * `user`
  * `empresa`
  * `admin`
* Usuários com role `user` não conseguem emitir certificados.
* Usuários com role `empresa` podem emitir certificados.
* Usuários com role `admin` possuem acesso administrativo.
* Mensagem padronizada de autorização:

  * `"Acesso negado. Permissão insuficiente para esta ação."`

#### Testes realizados

* Testes automatizados para autenticação e autorização por role.
* Testes de acesso permitido e negado para rotas protegidas.
* Testes de validação pública de certificados.
* Cobertura de testes atualizada para aproximadamente 90%.

#### Resultado

Middleware RBAC implementado e integrado às rotas protegidas do sistema, garantindo segregação de acesso entre alunos, empresas e administradores conforme os critérios definidos na tarefa.
