### PR TITLE
feat: Criar rota PUT events/{id} (#80)

### DIFF
--- a/api_certify/models/event_model.py
+++ b/api_certify/models/event_model.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, ConfigDict, field_validator
+from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
 from typing import Optional
 from datetime import datetime
 
@@ -88,3 +88,53 @@ class EventInDb(BaseModel):
     start_date: datetime = Field(..., description=DESC_START_DATE)
     end_date: datetime = Field(..., description=DESC_END_DATE)
     created_at: Optional[datetime] = None
+
+
+class UpdateEventSchema(BaseModel):
+    name: Optional[str] = Field(
+        None,
+        min_length=EVENT_NAME_MIN,
+        max_length=EVENT_NAME_MAX,
+        description=DESC_EVENT_NAME,
+        example=EXAMPLE_EVENT_NAME,
+    )
+    workload: Optional[int] = Field(
+        None,
+        description=DESC_WORKLOAD,
+        example=EXAMPLE_WORKLOAD,
+    )
+    description: Optional[str] = Field(
+        None,
+        description=DESC_DESCRIPTION,
+        example=EXAMPLE_DESCRIPTION,
+    )
+    start_date: Optional[datetime] = Field(
+        None,
+        description=DESC_START_DATE,
+        example=EXAMPLE_START_DATE,
+    )
+    end_date: Optional[datetime] = Field(
+        None,
+        description=DESC_END_DATE,
+        example=EXAMPLE_END_DATE,
+    )
+    @field_validator('workload')
+    @classmethod
+    def workload_must_be_positive(cls, v):
+        if v <= 0:
+            raise ValueError('Carga horária deve ser maior que zero')
+        return v
+
+    @model_validator(mode='after')
+    def validate_dates_together(self) -> 'UpdateEventSchema':
+        start = self.start_date
+        end = self.end_date
+
+        if (start is not None and end is None) or (start is None and end is not None):
+            raise ValueError('Ambas as datas (início e término) devem ser fornecidas juntas.')
+
+        if (start is not None) and (end is not None):
+            if end < start:
+                raise ValueError('Data de término não pode ser anterior à data de início')
+
+        return self

--- a/api_certify/repositories/event_repository.py
+++ b/api_certify/repositories/event_repository.py
@@ -3,7 +3,7 @@ from bson import ObjectId
 from bson.errors import InvalidId
 from motor.motor_asyncio import AsyncIOMotorDatabase, AsyncIOMotorCollection
 
-from api_certify.models.event_model import CreateEvent, EventInDb
+from api_certify.models.event_model import CreateEvent, EventInDb, UpdateEventSchema
 
 
 class EventRepository:
@@ -49,3 +49,25 @@ class EventRepository:
 
         doc = await self.collection.find_one({"_id": oid})
         return doc is not None
+
+    async def update(self, event_id: str, update_data: UpdateEventSchema) -> EventInDb | None:
+        fields = update_data.model_dump(exclude_none=True)
+
+        if not fields:
+                raise Exception("Nenhum campo para atualizar")
+        
+        fields["updated_at"] = datetime.now(timezone.utc)
+
+
+        result = await self.collection.find_one_and_update(
+            {"_id": ObjectId(event_id)},
+            {"$set": fields},
+            return_document=True,
+        )
+
+        if not result:
+            raise Exception("Evento não encontrado")
+
+        result["_id"] = str(result["_id"])
+
+        return EventInDb(**result)

--- a/api_certify/routes/v1/event_routes.py
+++ b/api_certify/routes/v1/event_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 
 from api_certify.dependencies import get_event_service, get_current_user
-from api_certify.models.event_model import CreateEvent
+from api_certify.models.event_model import CreateEvent, UpdateEventSchema
 from api_certify.schemas.responses import SucessResponse
 from api_certify.service.event_service import EventService
 
@@ -50,3 +50,38 @@ async def get_event(
         message="Evento obtido com sucesso.",
         data={"event": event},
     )
+
+@event_routes.put(
+    "/{event_id}",
+    response_model=SucessResponse,
+    status_code=200,
+)
+async def update_event(
+    event_id: str,
+    update_data: UpdateEventSchema,
+    service: EventService = Depends(get_event_service),
+    current_user: dict = Depends(get_current_user),
+):
+    try:
+        updated = await service.update_event(event_id, update_data)
+
+        return SucessResponse(
+            success=True,
+            message="Dados atualizados com sucesso",
+            data={"event": updated},
+        )
+
+    except HTTPException:
+        raise
+
+    except Exception as err:
+        error_message = str(err)
+
+        if "não encontrado" in error_message:
+            raise HTTPException(status_code=404, detail=error_message)
+
+        elif "já cadastrado" in error_message:
+            raise HTTPException(status_code=409, detail=error_message)
+
+        else:
+            raise HTTPException(status_code=400, detail=error_message)

--- a/api_certify/service/event_service.py
+++ b/api_certify/service/event_service.py
@@ -1,5 +1,5 @@
 from api_certify.repositories.event_repository import EventRepository
-from api_certify.models.event_model import CreateEvent, EventInDb
+from api_certify.models.event_model import CreateEvent, EventInDb, UpdateEventSchema
 
 
 class EventService:
@@ -12,3 +12,6 @@ class EventService:
 
     async def get_event_by_id(self, event_id: str) -> EventInDb | None:
         return await self.event_repository.find_by_id(event_id)
+
+    async def update_event(self, event_id: str, update_data: UpdateEventSchema) -> EventInDb | None:
+        return await self.event_repository.update(event_id, update_data)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -618,6 +618,138 @@ async def test_get_event_not_found(async_client, event_service_mock):
 
     assert response.status_code == 404
 
+# ==========================================
+# TESTS - UPDATE EVENT
+# ==========================================
+
+
+@pytest.mark.asyncio
+async def test_update_event_success(async_client, event_service_mock, auth_headers):
+
+    event_service_mock.update_event.return_value = {
+            "_id": "evt_123",
+            "name": "Evento Teste",
+            "institution": "Instituição",
+            "workload": 5,
+            "description": "Descrição",
+            "start_date": "2025-11-05T00:00:00",
+            "end_date": "2025-11-07T00:00:00",
+    }
+
+    response = await async_client.put(
+        "/api/v1/events/evt_123",
+        json={"name": "Evento Teste Atualizado"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+
+    body = response.json()
+
+    assert body["success"] is True
+    assert body["message"] == "Dados atualizados com sucesso"
+
+
+@pytest.mark.asyncio
+async def test_update_event_not_found(async_client, event_service_mock, auth_headers):
+
+    event_service_mock.update_event.side_effect = Exception("Evento não encontrado")
+
+    response = await async_client.put(
+        "/api/v1/events/evt_123",
+        json={"name": "Evento Teste Atualizado"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_event_negative_workload(
+    async_client, event_service_mock, auth_headers
+):
+
+    event_service_mock.update_event.return_value = {
+            "_id": "evt_123",
+            "name": "Evento Teste",
+            "workload": 5,
+    }
+
+    response = await async_client.put(
+        "/api/v1/events/evt_123",
+        json={
+            "name": "Evento Teste Atualizado",
+            "workload": 0,
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422 # Alerta de Unprocessable Content 
+
+@pytest.mark.asyncio
+async def test_update_event_invalid_dates(
+    async_client, event_service_mock, auth_headers
+):
+
+    event_service_mock.update_event.return_value = {
+            "_id": "evt_123",
+            "name": "Evento Teste",
+            "workload": 5,
+            "start_date": "2025-11-05T00:00:00",
+            "end_date": "2025-11-06T00:00:00"
+
+    }
+
+    response = await async_client.put(
+        "/api/v1/events/evt_123",
+        json={
+            "name": "Evento Teste Atualizado",
+            "start_date": "2025-11-05T00:00:00",
+            "end_date": "2025-11-04T00:00:00"
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422 # Alerta de Unprocessable Content 
+
+@pytest.mark.asyncio
+async def test_update_event_single_date(
+    async_client, event_service_mock, auth_headers
+):
+
+    event_service_mock.update_event.return_value = {
+            "_id": "evt_123",
+            "name": "Evento Teste",
+            "workload": 5,
+            "start_date": "2025-11-05T00:00:00",
+            "end_date": "2025-11-06T00:00:00"
+
+    }
+
+    response = await async_client.put(
+        "/api/v1/events/evt_123",
+        json={
+            "name": "Evento Teste Atualizado",
+            "end_date": "2025-11-04T00:00:00"
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422 # Alerta de Unprocessable Content 
+
+
+
+@pytest.mark.asyncio
+async def test_create_event_without_token(async_client_no_auth):
+
+    response = await async_client_no_auth.put(
+        "/api/v1/events/evt_123",
+        json={
+            "name": "Evento Teste Atualizado",
+        },
+    )
+
+    assert response.status_code == 403
 
 # ==========================================
 # TESTS - AUTH ENDPOINTS


### PR DESCRIPTION
https://tree.taiga.io/project/laridurao-liga-da-justica/task/80

### Entrega Realizada - Task #80

Foi implementada a rota de atualização de eventos (`PUT /events/{id}`), permitindo a modificação parcial dos dados cadastrados com validações de consistência de negócio e segurança por token.

#### Implementações realizadas

* **Criação do Schema de Atualização (`UpdateEventSchema`)**: Todos os campos foram definidos como opcionais para permitir atualizações parciais de dados.

* **Validação Conjunta de Datas**: Implementação de um `@model_validator(mode='after')` para garantir que `start_date` e `end_date` sejam enviados juntos e que a data de término não seja anterior à data de início.

* **Proteção da Rota**:
* `PUT /events/{event_id}` → Rota protegida utilizando a dependência `get_current_user`, exigindo token de autenticação ativo para a modificação de eventos.



#### Regras de negócio atendidas

* Os campos `start_date` e `end_date` tornam-se obrigatórios se um deles for preenchido.

* `404 Not Found` caso o evento não exista.

* `403 Forbidden` caso a requisição não possua o token de autenticação.

> [!WARNING] 
> **Erro não previsto**
> `422 Unprocessable Content` para falhas de validação de dados (Pydantic).

#### Testes realizados

* Teste automatizado de sucesso na atualização parcial de eventos.
* Teste de erro para tentativa de modificação em eventos inexistentes.
* Testes de validação de carga horária inválida (negativa ou zerada).
* Testes de validação de inconsistência de datas (fim anterior ao início ou envio de apenas uma das duas datas).
* Teste de restrição de segurança impedindo chamadas sem cabeçalho de autenticação (`auth_headers`).

#### Resultado

Rota de modificação de eventos integrada e em conformidade com a arquitetura do sistema (Model-Repository-Service-Route), assegurando regras rígidas de validação temporal do evento antes de sua persistência.