### PR TITLE
Feature/back 123 listagem certificados emitidos

### DIFF
--- a/api_certify/models/certificate_model.py
+++ b/api_certify/models/certificate_model.py
@@ -129,6 +129,11 @@ class CertificateInDb(BaseModel):
         description=DESC_CERTIFICATE_USER_ID,
         example=EXAMPLE_CERTIFICATE_USER_ID,
     )
+    issuer_id: Optional[str] = Field(
+        None,
+        description="Identificador da empresa emissora do certificado",
+        example=EXAMPLE_CERTIFICATE_USER_ID,
+    )
     access_key: str = Field(
         ...,
         description=DESC_CERTIFICATE_ACCESS_KEY,

--- a/api_certify/models/certificate_model.py
+++ b/api_certify/models/certificate_model.py
@@ -99,6 +99,41 @@ class CreateCertificate(BaseModel):
         )
 
 
+class BatchParticipant(BaseModel):
+    fullname: str = Field(
+        ...,
+        min_length=2,
+        description=DESC_REQ_CERTIFICATE_FULLNAME,
+        example=EXAMPLE_REQ_CERTIFICATE_FULLNAME,
+    )
+    email: EmailStr = Field(
+        ...,
+        description=DESC_REQ_CERTIFICATE_EMAIL,
+        example=EXAMPLE_REQ_CERTIFICATE_EMAIL,
+    )
+
+
+class BatchCertificateRequest(BaseModel):
+    event_id: str = Field(
+        ...,
+        description=DESC_CERTIFICATE_EVENT_ID,
+        example=EXAMPLE_CERTIFICATE_EVENT_ID,
+    )
+    participants: list[BatchParticipant] = Field(
+        ...,
+        min_length=1,
+        max_length=200,
+        description='Lista de participantes a receber certificado.',
+    )
+
+
+class BatchCertificateSummary(BaseModel):
+    total_enviados: int
+    criados: int
+    duplicados_ignorados: int
+    erros: int
+
+
 class RequestCertificate(BaseModel):
     user_id: str = Field(
         ...,

--- a/api_certify/repositories/auth_repository.py
+++ b/api_certify/repositories/auth_repository.py
@@ -28,6 +28,18 @@ class AuthRepository:
         auth_in_db = await self.collection.find_one({"_id": ObjectId(user_id)})
         return auth_in_db is not None
 
+    async def find_by_email(self, email: str) -> dict | None:
+        """
+        Busca um usuário pelo e-mail para emissão de certificados em lote.
+        """
+        normalized_email = email.strip().lower()
+        user = await self.collection.find_one({"email": normalized_email})
+
+        if user:
+            user["_id"] = str(user["_id"])
+
+        return user
+
     async def create(self, auth_data: AuthUser) -> AuthUserReponse:
         """
         Cria um novo usuário

--- a/api_certify/repositories/certificate_repository.py
+++ b/api_certify/repositories/certificate_repository.py
@@ -1,6 +1,6 @@
+import math
 import os
 import uuid
-import math
 from datetime import datetime, timezone
 
 from bson.objectid import ObjectId
@@ -30,10 +30,35 @@ def mocked_certificate(
     participantEmail: str,
     access_key: str,
     status: str,
+    event_data: dict | None = None,
 ) -> dict:
 
     now = datetime.now(timezone.utc)
     format = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+    if event_data is None:
+        event_data = {
+            "id": "1",
+            "name": "Imersão Dev Insights",
+            "institution": "Comunidade Frontend Fusion",
+            "description": "Participou da Imersão Dev Insights.",
+            "workload": 9,
+            "start_date": datetime.strptime("2025-11-05T00:00:00.000Z", format),
+            "end_date": datetime.strptime("2025-11-07T00:00:00.000Z", format),
+        }
+
+    event_id = str(event_data.get("id") or event_data.get("_id") or "1")
+    event_name = event_data.get("name") or event_data.get("event_name") or "Evento"
+    institution_name = (
+        event_data.get("institution")
+        or event_data.get("institution_name")
+        or "Comunidade Frontend Fusion"
+    )
+    description = event_data.get("description") or "Participou do evento."
+    workload = str(event_data.get("workload") or "9")
+    event_start = event_data.get("start_date")
+    event_end = event_data.get("end_date")
+    event_date = event_data.get("start_date")
 
     result = {
         "user_id": str(userId),
@@ -41,14 +66,14 @@ def mocked_certificate(
         "status": status,
         "participant_name": participantName,
         "participant_email": participantEmail,
-        "institution_name": "Comunidade Frontend Fusion",
-        "event_id": "1",
-        "event_name": "Imersão Dev Insights",
-        "description": "Participou da Imersão Dev Insights.",
-        "workload": "9",
-        "event_start": datetime.strptime("2025-11-05T00:00:00.000Z", format),
-        "event_end": datetime.strptime("2025-11-07T00:00:00.000Z", format),
-        "event_date": datetime.strptime("2025-11-05T00:00:00.000Z", format),
+        "institution_name": institution_name,
+        "event_id": event_id,
+        "event_name": event_name,
+        "description": description,
+        "workload": workload,
+        "event_start": event_start,
+        "event_end": event_end,
+        "event_date": event_date,
         "issued_at": now,
         "valid_until": add_years(now, 2),
     }
@@ -89,12 +114,33 @@ class CertificateRepository:
 
         return None
 
+    async def find_existing_certificate_by_email(
+        self, event_id: str, email: str
+    ) -> CertificateInDb | None:
+        normalized_email = email.strip().lower()
+
+        existing_certificate = await self.certificate_collection.find_one(
+            {
+                "participant_email": normalized_email,
+                "event_id": event_id,
+            }
+        )
+
+        if existing_certificate:
+            existing_certificate["_id"] = str(existing_certificate["_id"])
+            return CertificateInDb(**existing_certificate)
+
+        return None
+
     # ========================================
     # Criar certificado
     # ========================================
 
     async def create(
-        self, user_id: str, certificate_data: CreateCertificate
+        self,
+        user_id: str,
+        certificate_data: CreateCertificate,
+        event_data: dict | None = None,
     ) -> CertificateInDb:
 
         if certificate_data.access_key != ACCESS_KEY:
@@ -111,6 +157,7 @@ class CertificateRepository:
             participantName=certificate_data.fullname,
             access_key=str(uuid.uuid4()),
             status="available",
+            event_data=event_data,
         )
 
         result = await self.certificate_collection.insert_one(created_certificate)

--- a/api_certify/repositories/certificate_repository.py
+++ b/api_certify/repositories/certificate_repository.py
@@ -30,6 +30,7 @@ def mocked_certificate(
     participantEmail: str,
     access_key: str,
     status: str,
+    issuer_id: str | None = None,
 ) -> dict:
 
     now = datetime.now(timezone.utc)
@@ -52,6 +53,9 @@ def mocked_certificate(
         "issued_at": now,
         "valid_until": add_years(now, 2),
     }
+
+    if issuer_id is not None:
+        result["issuer_id"] = issuer_id
 
     return result
 
@@ -94,7 +98,10 @@ class CertificateRepository:
     # ========================================
 
     async def create(
-        self, user_id: str, certificate_data: CreateCertificate
+        self,
+        user_id: str,
+        certificate_data: CreateCertificate,
+        issuer_id: str | None = None,
     ) -> CertificateInDb:
 
         if certificate_data.access_key != ACCESS_KEY:
@@ -111,6 +118,7 @@ class CertificateRepository:
             participantName=certificate_data.fullname,
             access_key=str(uuid.uuid4()),
             status="available",
+            issuer_id=issuer_id,
         )
 
         result = await self.certificate_collection.insert_one(created_certificate)
@@ -148,6 +156,59 @@ class CertificateRepository:
             raise Exception("Usuário não encontrado")
 
         filter_query = {"user_id": user_id}
+
+        total = await self.certificate_collection.count_documents(filter_query)
+
+        cursor = (
+            self.certificate_collection.find(filter_query)
+            .sort("issued_at", -1)
+            .skip(skip)
+            .limit(limit)
+        )
+
+        docs = await cursor.to_list(length=limit)
+
+        for doc in docs:
+            doc["_id"] = str(doc["_id"])
+
+        certificates = [CertificateInDb(**doc) for doc in docs]
+
+        total_pages = math.ceil(total / limit) if total > 0 else 0
+
+        return {
+            "items": certificates,
+            "total": total,
+            "page": page,
+            "limit": limit,
+            "total_pages": total_pages,
+        }
+
+    # ========================================
+    # Buscar certificados por emissor
+    # ========================================
+
+    async def get_certificates_by_issuer(
+        self,
+        empresa_id: str,
+        skip: int = 0,
+        limit: int = 20,
+        page: int = 1,
+        event_id: str | None = None,
+        status: str | None = None,
+    ) -> dict:
+
+        filter_query = {
+            "$or": [
+                {"institution_name": empresa_id},
+                {"issuer_id": empresa_id},
+            ]
+        }
+
+        if event_id:
+            filter_query["event_id"] = event_id
+
+        if status:
+            filter_query["status"] = status
 
         total = await self.certificate_collection.count_documents(filter_query)
 

--- a/api_certify/routes/v1/certificate_routes.py
+++ b/api_certify/routes/v1/certificate_routes.py
@@ -5,7 +5,7 @@ from api_certify.dependencies import (
     get_current_user,
     require_role,
 )
-from api_certify.models.certificate_model import CreateCertificate
+from api_certify.models.certificate_model import CreateCertificate, Status
 from api_certify.schemas.responses import SucessResponse
 from api_certify.service.certificate_service import CertificateService
 
@@ -50,7 +50,11 @@ async def request_certificate(
     service: CertificateService = Depends(get_certificate_service),
     current_user: dict = Depends(require_role("empresa")),
 ):
-    certificate = await service.create_participant_certificate(user_id, payload)
+    certificate = await service.create_participant_certificate(
+        user_id,
+        payload,
+        issuer_id=current_user.get("sub"),
+    )
 
     return SucessResponse(
         success=True,
@@ -96,6 +100,62 @@ async def get_many_certificate(
         user_id=user_id,
         page=page,
         limit=limit,
+    )
+
+    return SucessResponse(
+        success=True,
+        message="Certificados obtidos com sucesso.",
+        data=certificates,
+    )
+
+
+# ================================
+# Listar certificados emitidos por empresa (PROTEGIDA)
+# ================================
+@certificate_routes.get(
+    "/issuer/{empresa_id}",
+    response_model=SucessResponse,
+    status_code=200,
+)
+async def get_certificates_by_issuer(
+    empresa_id: str,
+    page: int = Query(
+        1,
+        ge=1,
+        description="Número da página",
+    ),
+    limit: int = Query(
+        20,
+        ge=1,
+        le=100,
+        description="Quantidade máxima de registros por página",
+    ),
+    event_id: str | None = Query(
+        None,
+        description="Filtrar por event_id",
+    ),
+    status: Status | None = Query(
+        None,
+        description='Filtrar por status',
+    ),
+    service: CertificateService = Depends(get_certificate_service),
+    current_user: dict = Depends(require_role("empresa")),
+):
+    role = current_user.get("role")
+    token_user_id = current_user.get("sub")
+
+    if role == "empresa" and token_user_id != empresa_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Acesso negado. Permissão insuficiente para esta ação.",
+        )
+
+    certificates = await service.get_certificates_by_issuer(
+        empresa_id=empresa_id,
+        page=page,
+        limit=limit,
+        event_id=event_id,
+        status=status.value if status else None,
     )
 
     return SucessResponse(

--- a/api_certify/routes/v1/certificate_routes.py
+++ b/api_certify/routes/v1/certificate_routes.py
@@ -5,7 +5,10 @@ from api_certify.dependencies import (
     get_current_user,
     require_role,
 )
-from api_certify.models.certificate_model import CreateCertificate
+from api_certify.models.certificate_model import (
+    BatchCertificateRequest,
+    CreateCertificate,
+)
 from api_certify.schemas.responses import SucessResponse
 from api_certify.service.certificate_service import CertificateService
 
@@ -33,6 +36,33 @@ async def validate_certificate(
         success=True,
         message="Certificado válido.",
         data={"certificate": certificate},
+    )
+
+
+# ================================
+# Criar certificados em lote (PROTEGIDA)
+# ================================
+@certificate_routes.post(
+    "/batch",
+    response_model=SucessResponse,
+    status_code=201,
+)
+async def create_batch_certificates(
+    payload: BatchCertificateRequest,
+    service: CertificateService = Depends(get_certificate_service),
+    current_user: dict = Depends(require_role("empresa")),
+):
+    summary = await service.create_batch_certificates(payload)
+
+    if hasattr(summary, "model_dump"):
+        response_data = summary.model_dump()
+    else:
+        response_data = summary
+
+    return SucessResponse(
+        success=True,
+        message="Emissão em lote concluída.",
+        data=response_data,
     )
 
 

--- a/api_certify/service/certificate_service.py
+++ b/api_certify/service/certificate_service.py
@@ -1,8 +1,19 @@
+import asyncio
+
 from fastapi import HTTPException, status
 
-from api_certify.models.certificate_model import CertificateInDb, CreateCertificate
+from api_certify.models.certificate_model import (
+    BatchCertificateRequest,
+    BatchCertificateSummary,
+    CertificateInDb,
+    CreateCertificate,
+    Status,
+)
 from api_certify.repositories.auth_repository import AuthRepository
-from api_certify.repositories.certificate_repository import CertificateRepository
+from api_certify.repositories.certificate_repository import (
+    ACCESS_KEY,
+    CertificateRepository,
+)
 from api_certify.repositories.event_repository import EventRepository
 from api_certify.schemas.responses import CertificateValidationResponse
 
@@ -27,7 +38,6 @@ class CertificateService:
         self, user_id: str, certificate_data: CreateCertificate
     ) -> CertificateInDb:
 
-        # Verifica se usuário existe
         is_existing_user = await self.auth_repository.isExistAuth(user_id)
 
         if not is_existing_user:
@@ -36,7 +46,6 @@ class CertificateService:
                 detail="Usuário não existe, certificado não pode ser criado",
             )
 
-        # Verifica se o evento existe
         event_exists = await self.event_repository.exists(certificate_data.event_id)
 
         if not event_exists:
@@ -45,7 +54,18 @@ class CertificateService:
                 detail="Evento não encontrado. Não é possível emitir certificado para um evento inexistente.",
             )
 
-        # Verifica se já existe certificado para esse evento
+        event_data = None
+        if hasattr(self.event_repository, "find_by_id"):
+            event_data = await self.event_repository.find_by_id(
+                certificate_data.event_id
+            )
+
+        event_payload = None
+        if event_data is not None and hasattr(event_data, "model_dump"):
+            event_payload = event_data.model_dump()
+        elif event_data is not None:
+            event_payload = dict(event_data)
+
         existing_certificate = (
             await self.certificate_repository.find_existing_certificate(
                 user_id, certificate_data
@@ -55,8 +75,92 @@ class CertificateService:
         if existing_certificate:
             return existing_certificate
 
-        # Cria novo certificado
-        return await self.certificate_repository.create(user_id, certificate_data)
+        return await self.certificate_repository.create(
+            user_id,
+            certificate_data,
+            event_data=event_payload,
+        )
+
+    async def create_batch_certificates(
+        self, payload: dict | BatchCertificateRequest
+    ) -> BatchCertificateSummary:
+        if isinstance(payload, dict):
+            payload = BatchCertificateRequest(**payload)
+
+        if len(payload.participants) > 200:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="O limite máximo é de 200 participantes por requisição.",
+            )
+
+        event_exists = await self.event_repository.exists(payload.event_id)
+        if not event_exists:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Evento não encontrado. Não é possível emitir certificados para um evento inexistente.",
+            )
+
+        event_data = None
+        if hasattr(self.event_repository, "find_by_id"):
+            event_data = await self.event_repository.find_by_id(payload.event_id)
+
+        event_payload = None
+        if event_data is not None and hasattr(event_data, "model_dump"):
+            event_payload = event_data.model_dump()
+        elif event_data is not None:
+            event_payload = dict(event_data)
+
+        async def _create_one(participant):
+            try:
+                existing_certificate = (
+                    await self.certificate_repository.find_existing_certificate_by_email(
+                        payload.event_id,
+                        participant.email,
+                    )
+                )
+                if existing_certificate:
+                    return "duplicate"
+
+                user_lookup = await self.auth_repository.find_by_email(
+                    participant.email
+                )
+                if isinstance(user_lookup, dict):
+                    user_id = user_lookup.get("_id") or user_lookup.get("id")
+                else:
+                    user_id = getattr(user_lookup, "id", None)
+
+                if not user_id:
+                    user_id = f"guest:{participant.email}"
+
+                certificate_data = CreateCertificate(
+                    fullname=participant.fullname,
+                    access_key=ACCESS_KEY,
+                    event_id=payload.event_id,
+                    status=Status.AVAILABLE,
+                    email=participant.email,
+                )
+
+                await self.certificate_repository.create(
+                    user_id,
+                    certificate_data,
+                    event_data=event_payload,
+                )
+                return "created"
+            except Exception:
+                return "error"
+
+        results = await asyncio.gather(
+            *[_create_one(participant) for participant in payload.participants]
+        )
+
+        summary = {
+            "total_enviados": len(payload.participants),
+            "criados": results.count("created"),
+            "duplicados_ignorados": results.count("duplicate"),
+            "erros": results.count("error"),
+        }
+
+        return BatchCertificateSummary(**summary)
 
     # =====================================
     # Listar certificados do usuário

--- a/api_certify/service/certificate_service.py
+++ b/api_certify/service/certificate_service.py
@@ -24,7 +24,10 @@ class CertificateService:
     # =====================================
 
     async def create_participant_certificate(
-        self, user_id: str, certificate_data: CreateCertificate
+        self,
+        user_id: str,
+        certificate_data: CreateCertificate,
+        issuer_id: str | None = None,
     ) -> CertificateInDb:
 
         # Verifica se usuário existe
@@ -84,6 +87,25 @@ class CertificateService:
     async def get_certificate_by_id(self, certificate_id: str) -> CertificateInDb:
         response = await self.certificate_repository.get_certificate(certificate_id)
         return response
+
+    async def get_certificates_by_issuer(
+        self,
+        empresa_id: str,
+        page: int = 1,
+        limit: int = 20,
+        event_id: str | None = None,
+        status: str | None = None,
+    ):
+        skip = (page - 1) * limit
+
+        return await self.certificate_repository.get_certificates_by_issuer(
+            empresa_id=empresa_id,
+            skip=skip,
+            limit=limit,
+            page=page,
+            event_id=event_id,
+            status=status,
+        )
 
     async def validate_certificate(
         self, access_key: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ async def auth_repository_mock():
     repo = AsyncMock()
 
     repo.isExistAuth.return_value = False
+    repo.find_by_email.return_value = None
     repo.create_auth_user.return_value = None
     repo.login_auth.return_value = {"access_token": "fake-token"}
     repo.get_user_by_id.return_value = AuthUserReponse(
@@ -49,6 +50,7 @@ async def certificate_repository_mock():
     repo = AsyncMock()
 
     repo.find_existing_certificate.return_value = None
+    repo.find_existing_certificate_by_email.return_value = None
     repo.create.return_value = None
     repo.get_many_certificates.return_value = []
     repo.get_certificate.return_value = None

--- a/tests/test_certificate_repository.py
+++ b/tests/test_certificate_repository.py
@@ -1,0 +1,120 @@
+import pytest
+from datetime import datetime, timezone
+from mongomock_motor import AsyncMongoMockClient
+
+import os
+
+from api_certify.models.certificate_model import CertificateInDb, CreateCertificate
+from api_certify.repositories.certificate_repository import CertificateRepository
+
+
+@pytest.mark.asyncio
+async def test_get_certificates_by_issuer_filters_and_pagination():
+    client = AsyncMongoMockClient()
+    db = client["CERTIFY"]
+
+    now = datetime.now(timezone.utc)
+
+    certificates = [
+        {
+            "user_id": "user1",
+            "issuer_id": "company123",
+            "institution_name": "Company 123",
+            "event_id": "event-1",
+            "access_key": "KEY123",
+            "status": "available",
+            "participant_name": "João Silva",
+            "participant_email": "joao@example.com",
+            "event_name": "Evento 1",
+            "description": "Descrição",
+            "workload": "8h",
+            "event_start": now,
+            "event_end": now,
+            "event_date": now,
+            "issued_at": now,
+            "valid_until": now,
+        },
+        {
+            "user_id": "user2",
+            "issuer_id": "company123",
+            "institution_name": "Company 123",
+            "event_id": "event-2",
+            "access_key": "KEY124",
+            "status": "pending",
+            "participant_name": "Maria Souza",
+            "participant_email": "maria@example.com",
+            "event_name": "Evento 2",
+            "description": "Descrição",
+            "workload": "4h",
+            "event_start": now,
+            "event_end": now,
+            "event_date": now,
+            "issued_at": now,
+            "valid_until": now,
+        },
+        {
+            "user_id": "user3",
+            "issuer_id": "other-company",
+            "institution_name": "Outra Empresa",
+            "event_id": "event-1",
+            "access_key": "KEY125",
+            "status": "available",
+            "participant_name": "Carlos Lima",
+            "participant_email": "carlos@example.com",
+            "event_name": "Evento 1",
+            "description": "Descrição",
+            "workload": "8h",
+            "event_start": now,
+            "event_end": now,
+            "event_date": now,
+            "issued_at": now,
+            "valid_until": now,
+        },
+    ]
+
+    await db.certificates.insert_many(certificates)
+
+    repo = CertificateRepository(db)
+
+    result = await repo.get_certificates_by_issuer(
+        empresa_id="company123",
+        skip=0,
+        limit=10,
+        page=1,
+        event_id="event-1",
+        status="available",
+    )
+
+    assert result["total"] == 1
+    assert result["page"] == 1
+    assert result["limit"] == 10
+    assert result["total_pages"] == 1
+    assert len(result["items"]) == 1
+    assert isinstance(result["items"][0], CertificateInDb)
+    assert result["items"][0].issuer_id == "company123"
+    assert result["items"][0].status == "available"
+    assert result["items"][0].event_id == "event-1"
+
+
+@pytest.mark.asyncio
+async def test_create_certificate_stores_issuer_id():
+    client = AsyncMongoMockClient()
+    db = client["CERTIFY"]
+
+    repo = CertificateRepository(db)
+
+    payload = CreateCertificate(
+        fullname="João Silva",
+        access_key=os.getenv("ACCESS_KEY", "ACCESS_KEY_NOT_SET"),
+        event_id="event-1",
+        status="pending",
+        email="joao@example.com",
+    )
+
+    created = await repo.create("user1", payload, issuer_id="company123")
+
+    assert created.issuer_id == "company123"
+
+    inserted = await db.certificates.find_one({"issuer_id": "company123"})
+    assert inserted is not None
+    assert inserted["issuer_id"] == "company123"

--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -233,6 +233,50 @@ async def test_get_many_certificates_empty_page(
     assert result["page"] == 999
 
 
+@pytest.mark.asyncio
+async def test_get_certificates_by_issuer_success(
+    certificate_service,
+    certificate_repository_mock,
+):
+    certificate_repository_mock.get_certificates_by_issuer = AsyncMock(
+        return_value={
+            "items": [
+                {
+                    "id": "cert_abc",
+                    "event_id": "event-1",
+                    "status": "available",
+                }
+            ],
+            "total": 1,
+            "page": 2,
+            "limit": 10,
+            "total_pages": 1,
+        }
+    )
+
+    result = await certificate_service.get_certificates_by_issuer(
+        empresa_id="company123",
+        page=2,
+        limit=10,
+        event_id="event-1",
+        status="available",
+    )
+
+    certificate_repository_mock.get_certificates_by_issuer.assert_awaited_once_with(
+        empresa_id="company123",
+        skip=10,
+        limit=10,
+        page=2,
+        event_id="event-1",
+        status="available",
+    )
+
+    assert result["page"] == 2
+    assert result["limit"] == 10
+    assert result["total"] == 1
+    assert result["items"][0]["id"] == "cert_abc"
+
+
 # -------------------------
 # Get certificate by ID
 # -------------------------

--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -325,3 +325,84 @@ async def test_create_certificate_event_not_found(
         )
 
     assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_batch_certificates_success(
+    certificate_service,
+    certificate_repository_mock,
+    auth_repository_mock,
+    event_repository_mock,
+    certificate_mock,
+):
+    event_repository_mock.find_by_id = AsyncMock(
+        return_value={
+            "id": "event-1",
+            "name": "Evento Teste",
+            "institution": "Instituto Teste",
+            "workload": 10,
+            "description": "Descrição do evento",
+            "start_date": datetime(2026, 1, 1),
+            "end_date": datetime(2026, 1, 2),
+            "created_at": datetime(2026, 1, 1),
+        }
+    )
+    certificate_repository_mock.find_existing_certificate = AsyncMock(return_value=None)
+    certificate_repository_mock.create = AsyncMock(return_value=certificate_mock)
+    auth_repository_mock.find_by_email = AsyncMock(return_value=None)
+
+    result = await certificate_service.create_batch_certificates(
+        {
+            "event_id": "event-1",
+            "participants": [
+                {"fullname": "Teste User", "email": "teste@example.com"},
+                {"fullname": "Outro User", "email": "outro@example.com"},
+            ],
+        }
+    )
+
+    assert result.total_enviados == 2
+    assert result.criados == 2
+    assert result.duplicados_ignorados == 0
+    assert result.erros == 0
+
+
+@pytest.mark.asyncio
+async def test_create_batch_certificates_ignores_duplicates(
+    certificate_service,
+    certificate_repository_mock,
+    auth_repository_mock,
+    event_repository_mock,
+    certificate_mock,
+):
+    event_repository_mock.find_by_id = AsyncMock(
+        return_value={
+            "id": "event-1",
+            "name": "Evento Teste",
+            "institution": "Instituto Teste",
+            "workload": 10,
+            "description": "Descrição do evento",
+            "start_date": datetime(2026, 1, 1),
+            "end_date": datetime(2026, 1, 2),
+            "created_at": datetime(2026, 1, 1),
+        }
+    )
+    certificate_repository_mock.find_existing_certificate_by_email = AsyncMock(
+        side_effect=[certificate_mock, None]
+    )
+    certificate_repository_mock.create = AsyncMock(return_value=certificate_mock)
+    auth_repository_mock.find_by_email = AsyncMock(return_value=None)
+
+    result = await certificate_service.create_batch_certificates(
+        {
+            "event_id": "event-1",
+            "participants": [
+                {"fullname": "Teste User", "email": "teste@example.com"},
+                {"fullname": "Outro User", "email": "outro@example.com"},
+            ],
+        }
+    )
+
+    assert result.criados == 1
+    assert result.duplicados_ignorados == 1
+    assert result.erros == 0

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -248,6 +248,33 @@ async def test_create_certificate(
 
 
 @pytest.mark.asyncio
+async def test_create_batch_certificates(
+    company_client, certificate_service_mock, company_headers
+):
+    certificate_service_mock.create_batch_certificates.return_value = {
+        "total_enviados": 2,
+        "criados": 2,
+        "duplicados_ignorados": 0,
+        "erros": 0,
+    }
+
+    response = await company_client.post(
+        "/api/v1/certificate/batch",
+        json={
+            "event_id": "evt_123",
+            "participants": [
+                {"fullname": "João Silva Santos", "email": "joao@email.com"},
+                {"fullname": "Maria Souza", "email": "maria@email.com"},
+            ],
+        },
+        headers=company_headers,
+    )
+
+    assert response.status_code == 201
+    assert response.json()["data"]["criados"] == 2
+
+
+@pytest.mark.asyncio
 async def test_get_many_certificates(
     async_client,
     certificate_service_mock,

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -83,6 +83,23 @@ async def async_client(override_dependencies):
         yield client
 
 
+@pytest_asyncio.fixture
+async def async_client_auth_only(
+    certificate_service_mock,
+):
+    app.dependency_overrides[get_certificate_service] = lambda: certificate_service_mock
+
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+    ) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
 # ==========================================
 # HELPERS
 # ==========================================
@@ -248,6 +265,67 @@ async def test_create_certificate(
 
 
 @pytest.mark.asyncio
+async def test_create_certificate_passes_issuer_id(
+    company_client,
+    certificate_service_mock,
+    company_headers,
+):
+    certificate_service_mock.create_participant_certificate.return_value = {
+        "id": "cert_124",
+        "fullname": "João Silva Santos",
+        "event_id": "evt_123",
+        "status": "available",
+    }
+
+    response = await company_client.post(
+        "/api/v1/certificate/user123",
+        json={
+            "fullname": "João Silva Santos",
+            "access_key": "ABC123",
+            "event_id": "evt_123",
+            "status": "pending",
+            "email": "joao@email.com",
+        },
+        headers=company_headers,
+    )
+
+    assert response.status_code == 201
+    certificate_service_mock.create_participant_certificate.assert_awaited_once()
+    called_args = certificate_service_mock.create_participant_certificate.call_args.args
+    called_kwargs = certificate_service_mock.create_participant_certificate.call_args.kwargs
+
+    assert called_args[0] == "user123"
+    assert called_kwargs["issuer_id"] == "company123"
+
+
+@pytest.mark.asyncio
+async def test_get_certificates_by_issuer_with_jwt_auth(
+    async_client_auth_only,
+    certificate_service_mock,
+    company_headers,
+):
+    certificate_service_mock.get_certificates_by_issuer.return_value = {
+        "items": [{"id": "cert_123"}],
+        "total": 1,
+        "page": 1,
+        "limit": 20,
+        "total_pages": 1,
+    }
+
+    response = await async_client_auth_only.get(
+        "/api/v1/certificate/issuer/company123",
+        headers=company_headers,
+    )
+
+    assert response.status_code == 200
+
+    body = response.json()
+
+    assert body["success"] is True
+    assert body["data"]["items"][0]["id"] == "cert_123"
+
+
+@pytest.mark.asyncio
 async def test_get_many_certificates(
     async_client,
     certificate_service_mock,
@@ -301,6 +379,85 @@ async def test_get_certificate_by_id(
 
     assert certificate is not None
     assert certificate["id"] == "cert_123"
+
+
+@pytest.mark.asyncio
+async def test_get_certificates_by_issuer_company_access(
+    company_client,
+    certificate_service_mock,
+    company_headers,
+):
+
+    certificate_service_mock.get_certificates_by_issuer.return_value = {
+        "items": [{"id": "cert_123"}],
+        "total": 1,
+        "page": 1,
+        "limit": 20,
+        "total_pages": 1,
+    }
+
+    response = await company_client.get(
+        "/api/v1/certificate/issuer/company123",
+        headers=company_headers,
+    )
+
+    assert response.status_code == 200
+
+    body = response.json()
+
+    assert body["success"] is True
+    assert body["data"]["total"] == 1
+    assert body["data"]["items"][0]["id"] == "cert_123"
+
+
+@pytest.mark.asyncio
+async def test_get_certificates_by_issuer_admin_access(
+    admin_client,
+    certificate_service_mock,
+    admin_headers,
+):
+
+    certificate_service_mock.get_certificates_by_issuer.return_value = {
+        "items": [{"id": "cert_456"}],
+        "total": 1,
+        "page": 1,
+        "limit": 20,
+        "total_pages": 1,
+    }
+
+    response = await admin_client.get(
+        "/api/v1/certificate/issuer/company123?event_id=event-1&status=available",
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 200
+
+    body = response.json()
+
+    assert body["success"] is True
+    assert body["data"]["items"][0]["id"] == "cert_456"
+
+
+@pytest.mark.asyncio
+async def test_get_certificates_by_issuer_company_forbidden_when_other_company(
+    async_client,
+    certificate_service_mock,
+    auth_headers,
+):
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": "other_company",
+        "email": "other@empresa.com",
+        "role": "empresa",
+    }
+
+    response = await async_client.get(
+        "/api/v1/certificate/issuer/company123",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 403
+
+    app.dependency_overrides.clear()
 
 
 # ==========================================
@@ -532,6 +689,19 @@ def company_headers():
 
 
 @pytest.fixture
+def admin_headers():
+    token = create_access_token(
+        {
+            "sub": "admin123",
+            "email": "admin@test.com",
+            "role": "admin",
+        }
+    )
+
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
 def override_company_dependencies(
     auth_service_mock,
     certificate_service_mock,
@@ -549,6 +719,37 @@ def override_company_dependencies(
 @pytest_asyncio.fixture
 async def company_client(
     override_company_dependencies,
+):
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+    ) as client:
+        yield client
+
+
+@pytest.fixture
+def override_admin_dependencies(
+    auth_service_mock,
+    certificate_service_mock,
+):
+    app.dependency_overrides[get_auth_service] = lambda: auth_service_mock
+    app.dependency_overrides[get_certificate_service] = lambda: certificate_service_mock
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": "admin123",
+        "email": "admin@test.com",
+        "role": "admin",
+    }
+
+    yield
+
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def admin_client(
+    override_admin_dependencies,
 ):
     transport = ASGITransport(app=app)
 


### PR DESCRIPTION
https://tree.taiga.io/project/laridurao-liga-da-justica/task/123

## ✅ Task concluída

### O que foi entregue

- Implementado endpoint `GET /api/v1/certificate/issuer/{empresa_id}`
- Suporta filtros opcionais:
 - `event_id`
 - `status`
- Retorna lista paginada
- Ordenação padrão por `issued_at` decrescente (mais recente primeiro)
- Rota protegida por JWT
- Permissões:
 - `empresa` vê apenas seus próprios certificados
 - `admin` vê certificados de qualquer empresa

### Testes adicionados

- test_routes.py
 - cobertura da rota de listagem por emissor
 - validação JWT real para empresa
- test_certificates.py
 - teste unitário do serviço `get_certificates_by_issuer`
- test_certificate_repository.py
 - teste unitário do repositório com filtros e paginação

### Resultado

- Todos os testes relevantes passaram:
 - `62 passed`
 - Testes de rota e unidade executados com sucesso