### PR TITLE
feat: adiciona fluxo de recuperação de senha

### DIFF
--- a/api_certify/models/auth_model.py
+++ b/api_certify/models/auth_model.py
@@ -73,6 +73,27 @@ class AuthUserLogin(BaseModel):
     )
 
 
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr = Field(..., description=DESC_EMAIL, example=EXAMPLE_EMAIL)
+
+
+class VerifyCodeRequest(BaseModel):
+    email: EmailStr = Field(..., description=DESC_EMAIL, example=EXAMPLE_EMAIL)
+    code: str = Field(..., min_length=6, max_length=6, description="Código de verificação")
+
+
+class ResetPasswordRequest(BaseModel):
+    email: EmailStr = Field(..., description=DESC_EMAIL, example=EXAMPLE_EMAIL)
+    code: str = Field(..., min_length=6, max_length=6, description="Código de verificação")
+    new_password: str = Field(
+        ...,
+        max_length=PASSWORD_MAX,
+        min_length=PASSWORD_MIN,
+        description=DESC_PASSWORD,
+        example=EXAMPLE_PASSWORD,
+    )
+
+
 class AuthUserInDb(AuthUser):
     id: str = Field(..., alias="_id", description=DESC_USER_ID, example=EXAMPLE_USER_ID)
     model_config = ConfigDict(use_enum_values=True, populate_by_name=True)

--- a/api_certify/repositories/auth_repository.py
+++ b/api_certify/repositories/auth_repository.py
@@ -108,6 +108,95 @@ class AuthRepository:
 
         return AuthUserReponse(**auth_in_db)
 
+    async def get_user_by_email(self, email: str) -> AuthUserReponse | None:
+        auth_in_db = await self.collection.find_one({"email": email})
+
+        if not auth_in_db:
+            return None
+
+        auth_in_db["_id"] = str(auth_in_db["_id"])
+        if "password" in auth_in_db:
+            del auth_in_db["password"]
+
+        return AuthUserReponse(**auth_in_db)
+
+    async def store_password_reset_code(
+        self, user_id: str, code_hash: str, expires_at: datetime
+    ) -> None:
+        result = await self.collection.update_one(
+            {"_id": ObjectId(user_id)},
+            {
+                "$set": {
+                    "password_reset_code": code_hash,
+                    "password_reset_expires_at": expires_at,
+                    "password_reset_used": False,
+                }
+            },
+        )
+
+        if result.matched_count == 0:
+            raise Exception("Usuário não encontrado")
+
+    async def verify_password_reset_code(self, user_id: str, code: str) -> dict:
+        auth_in_db = await self.collection.find_one({"_id": ObjectId(user_id)})
+
+        if not auth_in_db:
+            return {"success": False, "message": "Usuário não encontrado"}
+
+        stored_hash = auth_in_db.get("password_reset_code")
+        expires_at = auth_in_db.get("password_reset_expires_at")
+        used = auth_in_db.get("password_reset_used", False)
+
+        if not stored_hash or used or not expires_at:
+            return {"success": False, "message": "Código inválido ou expirado"}
+
+        if expires_at < datetime.now(timezone.utc):
+            return {"success": False, "message": "Código inválido ou expirado"}
+
+        if not HashManager.verify_password(code, stored_hash):
+            return {"success": False, "message": "Código inválido ou expirado"}
+
+        return {"success": True, "message": "Código verificado com sucesso"}
+
+    async def reset_password_with_code(
+        self, user_id: str, code: str, new_password: str
+    ) -> dict:
+        auth_in_db = await self.collection.find_one({"_id": ObjectId(user_id)})
+
+        if not auth_in_db:
+            return {"success": False, "message": "Usuário não encontrado"}
+
+        stored_hash = auth_in_db.get("password_reset_code")
+        expires_at = auth_in_db.get("password_reset_expires_at")
+        used = auth_in_db.get("password_reset_used", False)
+
+        if not stored_hash or used or not expires_at:
+            return {"success": False, "message": "Código inválido ou expirado"}
+
+        if expires_at < datetime.now(timezone.utc):
+            return {"success": False, "message": "Código inválido ou expirado"}
+
+        if not HashManager.verify_password(code, stored_hash):
+            return {"success": False, "message": "Código inválido ou expirado"}
+
+        result = await self.collection.update_one(
+            {"_id": ObjectId(user_id)},
+            {
+                "$set": {
+                    "password": HashManager.hash_password(new_password),
+                    "password_reset_code": None,
+                    "password_reset_expires_at": None,
+                    "password_reset_used": True,
+                    "updated_at": datetime.now(timezone.utc),
+                }
+            },
+        )
+
+        if result.matched_count == 0:
+            return {"success": False, "message": "Usuário não encontrado"}
+
+        return {"success": True, "message": "Senha redefinida com sucesso"}
+
     async def update(
         self, user_id: str, update_data: UpdateUserSchema
     ) -> AuthUserReponse:

--- a/api_certify/service/auth_service.py
+++ b/api_certify/service/auth_service.py
@@ -1,9 +1,14 @@
+import logging
+import secrets
+import string
 from datetime import datetime, timedelta, timezone
+import re
 
 from fastapi import HTTPException, status
 
 from api_certify.core.security import (
     REFRESH_TOKEN_EXPIRE_DAYS,
+    HashManager,
     create_access_token,
     create_refresh_token,
     decode_refresh_token,
@@ -18,6 +23,9 @@ from api_certify.models.auth_model import (
 )
 from api_certify.repositories.auth_repository import AuthRepository
 from api_certify.repositories.refresh_token_repository import RefreshTokenRepository
+
+logger = logging.getLogger(__name__)
+PASSWORD_RESET_CODE_TTL_MINUTES = 10
 
 
 class AuthService:
@@ -141,6 +149,99 @@ class AuthService:
             )
 
         return {"message": "Sessão encerrada com sucesso"}
+
+    def _generate_reset_code(self) -> str:
+        return "".join(secrets.choice(string.digits) for _ in range(6))
+
+    def _send_password_reset_code(self, email: str, code: str) -> None:
+        logger.info("Código de recuperação para %s: %s", email, code)
+
+    def _is_strong_password(self, password: str) -> bool:
+        if len(password) < 8:
+            return False
+
+        has_upper = bool(re.search(r"[A-Z]", password))
+        has_lower = bool(re.search(r"[a-z]", password))
+        has_digit = bool(re.search(r"\d", password))
+        has_special = bool(re.search(r"[^A-Za-z0-9]", password))
+
+        return has_upper and has_lower and has_digit and has_special
+
+    async def forgot_password(self, email: str) -> dict:
+        user = await self.auth_repository.get_user_by_email(email)
+
+        if not user:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Usuário não encontrado",
+            )
+
+        code = self._generate_reset_code()
+        code_hash = HashManager.hash_password(code)
+        expires_at = datetime.now(timezone.utc) + timedelta(
+            minutes=PASSWORD_RESET_CODE_TTL_MINUTES
+        )
+
+        await self.auth_repository.store_password_reset_code(
+            user_id=str(user.id),
+            code_hash=code_hash,
+            expires_at=expires_at,
+        )
+
+        self._send_password_reset_code(email, code)
+
+        return {"message": "Código de recuperação enviado"}
+
+    async def verify_code(self, email: str, code: str) -> dict:
+        user = await self.auth_repository.get_user_by_email(email)
+
+        if not user:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Usuário não encontrado",
+            )
+
+        result = await self.auth_repository.verify_password_reset_code(
+            user_id=str(user.id),
+            code=code,
+        )
+
+        if result.get("success") is False:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=result["message"],
+            )
+
+        return result
+
+    async def reset_password(self, email: str, code: str, new_password: str) -> dict:
+        if not self._is_strong_password(new_password):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Senha não atende aos requisitos de segurança",
+            )
+
+        user = await self.auth_repository.get_user_by_email(email)
+
+        if not user:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Usuário não encontrado",
+            )
+
+        result = await self.auth_repository.reset_password_with_code(
+            user_id=str(user.id),
+            code=code,
+            new_password=new_password,
+        )
+
+        if result.get("success") is False:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=result["message"],
+            )
+
+        return result
 
     async def get_me(self, user_id: str) -> AuthUserReponse:
         return await self.auth_repository.get_user_by_id(user_id)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -62,6 +62,39 @@ async def test_login_success(auth_service, auth_repository_mock):
 
 
 @pytest.mark.asyncio
+async def test_forgot_password_unknown_email_raises_not_found(auth_service, auth_repository_mock):
+    auth_repository_mock.get_user_by_email = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_service.forgot_password("naoexiste@example.com")
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Usuário não encontrado"
+
+
+@pytest.mark.asyncio
+async def test_verify_code_invalid_or_expired_raises_bad_request(auth_service, auth_repository_mock):
+    auth_repository_mock.get_user_by_email = AsyncMock(
+        return_value=AuthUserReponse(
+            _id="1",
+            fullname="Teste User",
+            email="teste@example.com",
+            role=Role.USER,
+            status="pending",
+        )
+    )
+    auth_repository_mock.verify_password_reset_code = AsyncMock(
+        return_value={"success": False, "message": "Código inválido ou expirado"}
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_service.verify_code("teste@example.com", "000000")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Código inválido ou expirado"
+
+
+@pytest.mark.asyncio
 async def test_signup_duplicate_email(auth_service, auth_repository_mock):
 
     payload = AuthUser(


### PR DESCRIPTION
https://tree.taiga.io/project/laridurao-liga-da-justica/task/153

✅ Feito!

A implementação da task [#153](https://github.com/Projeto-FrontEnd-Fusion/API_CERTIFY/compare/main...estevaoMG:API_CERTIFY:feature/project/laridurao-liga-da-justica/t/153) foi concluída com foco no fluxo de recuperação de senha.

O que foi implementado

Adição do fluxo de recuperação de senha no serviço de autenticação:

solicitação de código via e-mail
validação do código informado
redefinição da senha
validação de força da nova senha
Inclusão dos modelos de entrada para os endpoints:

forgot-password
verify-code
reset-password
Implementação no repositório para persistir e validar o código de recuperação, incluindo:

armazenamento do hash do código
expiração do código
invalidação após uso
Criação de testes unitários cobrindo:

usuário inexistente
código inválido ou expirado

Arquivos alterados

auth_service.py
auth_model.py
auth_repository.py
test_auth.py

Verificação

Teste executado:

poetry run pytest -q test_auth.py

Resultado:

15 passed in 0.16s