### PR TITLE
test: add unit test for empty issuer certificate listing

### DIFF
--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -277,6 +277,41 @@ async def test_get_certificates_by_issuer_success(
     assert result["items"][0]["id"] == "cert_abc"
 
 
+@pytest.mark.asyncio
+async def test_get_certificates_by_issuer_returns_empty_when_none_found(
+    certificate_service,
+    certificate_repository_mock,
+):
+    certificate_repository_mock.get_certificates_by_issuer = AsyncMock(
+        return_value={
+            "items": [],
+            "total": 0,
+            "page": 1,
+            "limit": 20,
+            "total_pages": 0,
+        }
+    )
+
+    result = await certificate_service.get_certificates_by_issuer(
+        empresa_id="company123",
+        page=1,
+        limit=20,
+    )
+
+    certificate_repository_mock.get_certificates_by_issuer.assert_awaited_once_with(
+        empresa_id="company123",
+        skip=0,
+        limit=20,
+        page=1,
+        event_id=None,
+        status=None,
+    )
+
+    assert result["items"] == []
+    assert result["total"] == 0
+    assert result["total_pages"] == 0
+
+
 # -------------------------
 # Get certificate by ID
 # -------------------------


### PR DESCRIPTION
https://tree.taiga.io/project/laridurao-liga-da-justica/task/155

A task foi respondida com foco no escopo de teste unitário da funcionalidade de listagem de certificados emitidos pela empresa.

O que foi entregue: 
- Criação de uma branch de feature a partir da main. 
- Implementação de um teste unitário em test_certificates.py para cobrir o cenário em que a consulta por emissor retorna uma lista vazia. 
- Validação do fluxo de chamada do serviço para o repositório, incluindo o contrato de resposta esperado para o caso de ausência de registros.

Importante: 
- A implementação da funcionalidade de produção já existia no projeto, então a entrega foi voltada à cobertura automática do comportamento esperado, e não à criação da lógica de negócio do endpoint em si.

Validação executada: 
- Comando: `pytest -q test_certificates.py -k 'issuer_returns_empty_when_none_found or get_certificates_by_issuer_success'` 
- Resultado: `2 passed, 14 deselected in 0.09s`

Essa resposta mantém o alinhamento com a história de usuário, pois o teste garante que a listagem por empresa seja tratada corretamente mesmo quando nenhum certificado for encontrado.