### PR TITLE
test: add batch certificate error coverage

### DIFF
--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -450,3 +450,44 @@ async def test_create_batch_certificates_ignores_duplicates(
     assert result.criados == 1
     assert result.duplicados_ignorados == 1
     assert result.erros == 0
+
+
+@pytest.mark.asyncio
+async def test_create_batch_certificates_counts_errors_for_failed_participants(
+    certificate_service,
+    certificate_repository_mock,
+    auth_repository_mock,
+    event_repository_mock,
+    certificate_mock,
+):
+    event_repository_mock.find_by_id = AsyncMock(
+        return_value={
+            "id": "event-1",
+            "name": "Evento Teste",
+            "institution": "Instituto Teste",
+            "workload": 10,
+            "description": "Descrição do evento",
+            "start_date": datetime(2026, 1, 1),
+            "end_date": datetime(2026, 1, 2),
+            "created_at": datetime(2026, 1, 1),
+        }
+    )
+    certificate_repository_mock.find_existing_certificate_by_email = AsyncMock(
+        return_value=None
+    )
+    certificate_repository_mock.create = AsyncMock(side_effect=Exception("boom"))
+    auth_repository_mock.find_by_email = AsyncMock(return_value=None)
+
+    result = await certificate_service.create_batch_certificates(
+        {
+            "event_id": "event-1",
+            "participants": [
+                {"fullname": "Teste User", "email": "teste@example.com"},
+                {"fullname": "Outro User", "email": "outro@example.com"},
+            ],
+        }
+    )
+
+    assert result.criados == 0
+    assert result.duplicados_ignorados == 0
+    assert result.erros == 2


### PR DESCRIPTION
https://tree.taiga.io/project/laridurao-liga-da-justica/task/156

Implementei a branch de feature para a task [#156](https://github.com/Projeto-FrontEnd-Fusion/API_CERTIFY/compare/main...estevaoMG:API_CERTIFY:feature/project/laridurao-liga-da-justica/t/156) a partir da main:

- Branch criada: `feature/156-emissao-certificados-lote`

O que foi entregue: 
- Adição de um teste unitário em test_certificates.py cobrindo o cenário de emissão em lote em que a criação de participantes falha. 
- O teste valida que o serviço contabiliza corretamente os erros da operação, alinhado ao fluxo atual de processamento em lote.

Detalhe importante: 
- A lógica atual já trata duplicidade e falhas de forma agregada no serviço de emissão em lote, então a entrega foi focada em ampliar a cobertura automática desse comportamento, sem alterar a implementação existente.

Validação executada: 
- Comando: `pytest -q test_certificates.py -k 'create_batch_certificates'` 
- Resultado: `3 passed, 13 deselected in 0.09s`

Isso reforça a cobertura da história de usuário relacionada à emissão em lote, especialmente no cenário em que parte dos participantes não consegue ser processada corretamente.