### PR TITLE
feat: adicionar suporte para ativar/desativar status de certificado

### DIFF
--- a/api_certify/repositories/certificate_repository.py
+++ b/api_certify/repositories/certificate_repository.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 
 from bson.objectid import ObjectId
 from motor.motor_asyncio import AsyncIOMotorCollection, AsyncIOMotorDatabase
+from pymongo import ReturnDocument
 
 from api_certify.models.certificate_model import CertificateInDb, CreateCertificate
 
@@ -297,6 +298,19 @@ class CertificateRepository:
         existingCertificate["_id"] = str(existingCertificate["_id"])
 
         return CertificateInDb(**existingCertificate)
+
+    async def update_status(self, certificate_id: str, status: str) -> CertificateInDb | None:
+        updated_doc = await self.certificate_collection.find_one_and_update(
+            {"_id": ObjectId(certificate_id)},
+            {"$set": {"status": status}},
+            return_document=ReturnDocument.AFTER,
+        )
+
+        if not updated_doc:
+            return None
+
+        updated_doc["_id"] = str(updated_doc["_id"])
+        return CertificateInDb(**updated_doc)
 
     # ========================================
     # Buscar certificado por access_key

--- a/api_certify/routes/v1/certificate_routes.py
+++ b/api_certify/routes/v1/certificate_routes.py
@@ -199,6 +199,29 @@ async def get_certificates_by_issuer(
 # ================================
 # Buscar certificado por ID (PROTEGIDA)
 # ================================
+@certificate_routes.patch(
+    "/{item_id}/status",
+    response_model=SucessResponse,
+    status_code=200,
+)
+async def update_certificate_status(
+    item_id: str,
+    status: str = Query(
+        ...,
+        description="Status do certificado: active ou inactive",
+    ),
+    service: CertificateService = Depends(get_certificate_service),
+    current_user: dict = Depends(require_role("empresa")),
+):
+    certificate = await service.update_certificate_status(item_id, status)
+
+    return SucessResponse(
+        success=True,
+        message="Status do certificado atualizado com sucesso.",
+        data={"certificate": certificate},
+    )
+
+
 @certificate_routes.get(
     "/{item_id}",
     response_model=SucessResponse,

--- a/api_certify/service/certificate_service.py
+++ b/api_certify/service/certificate_service.py
@@ -211,6 +211,40 @@ class CertificateService:
             status=status,
         )
 
+    async def update_certificate_status(
+        self,
+        certificate_id: str,
+        status: str,
+    ) -> CertificateInDb:
+        normalized_status = self._normalize_status(status)
+
+        certificate = await self.certificate_repository.update_status(
+            certificate_id=certificate_id,
+            status=normalized_status,
+        )
+
+        if not certificate:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Certificado não encontrado.",
+            )
+
+        return certificate
+
+    def _normalize_status(self, status: str) -> str:
+        normalized_status = (status or "").strip().lower()
+
+        if normalized_status in {"active", "available"}:
+            return "available"
+
+        if normalized_status in {"inactive", "disabled"}:
+            return "inactive"
+
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Status inválido. Use 'active' ou 'inactive'.",
+        )
+
     async def validate_certificate(
         self, access_key: str
     ) -> CertificateValidationResponse:

--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -311,6 +311,26 @@ async def test_get_certificate_by_id_not_found(
         await certificate_service.get_certificate_by_id("invalid-id")
 
 
+@pytest.mark.asyncio
+async def test_update_certificate_status_success(
+    certificate_service,
+    certificate_repository_mock,
+    certificate_mock,
+):
+    certificate_repository_mock.update_status = AsyncMock(return_value=certificate_mock)
+
+    result = await certificate_service.update_certificate_status(
+        certificate_id="cert-1",
+        status="inactive",
+    )
+
+    certificate_repository_mock.update_status.assert_awaited_once_with(
+        certificate_id="cert-1",
+        status="inactive",
+    )
+    assert result.status == "available"
+
+
 # -------------------------
 # Validate certificate
 # -------------------------


### PR DESCRIPTION
https://tree.taiga.io/project/laridurao-liga-da-justica/task/157

A feature de ativar/desativar certificado foi implementada na branch feature/157-ativar-desativar-certificado com cobertura de teste unitário.

### O que foi entregue 
- Adição do fluxo de alteração de status via endpoint PATCH /certificate/{id}/status. 
- Suporte para os valores active/inactive, com normalização para o estado interno do sistema. 
- Atualização do status no repositório e retorno do certificado atualizado. 
- Teste unitário cobrindo a alteração de status no serviço.

### Arquivos ajustados 
- test_certificates.py 
- certificate_service.py 
- certificate_repository.py 
- certificate_routes.py

### Verificação 
Execução confirmada com: 
- `.venv/bin/python -m pytest -q tests/test_certificates.py`

Resultado: 
- 16 passed in 0.18s