### PR TITLE
feat: adicionar teste unitário para edição de evento

### DIFF
--- a/tests/test_event_service.py
+++ b/tests/test_event_service.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api_certify.models.event_model import EventInDb, UpdateEventSchema
+from api_certify.service.event_service import EventService
+
+
+@pytest.mark.asyncio
+async def test_update_event_delegates_to_repository_and_returns_updated_event():
+    repository = AsyncMock()
+    repository.update.return_value = EventInDb(
+        _id="event-123",
+        name="Evento Atualizado",
+        institution="Instituição",
+        workload=12,
+        description="Descrição atualizada",
+        start_date=datetime(2025, 11, 5, 0, 0),
+        end_date=datetime(2025, 11, 7, 0, 0),
+    )
+
+    service = EventService(repository)
+    payload = UpdateEventSchema(name="Evento Atualizado", workload=12)
+
+    result = await service.update_event("event-123", payload)
+
+    repository.update.assert_awaited_once_with("event-123", payload)
+    assert result is not None
+    assert result.name == "Evento Atualizado"
+    assert result.workload == 12


### PR DESCRIPTION
https://tree.taiga.io/project/laridurao-liga-da-justica/task/158

A funcionalidade de editar evento já estava implementada na API, por meio do fluxo de atualização do endpoint PUT /events/{id}, incluindo a chamada ao serviço e ao repositório para persistir as alterações. Nesta branch, a contribuição foi adicionar cobertura de teste unitário para garantir esse comportamento, sem alterar a lógica de negócio já existente. O teste foi incluído em test_event_service.py e validado com o comando source .venv/bin/activate && pytest -q tests/test_event_service.py, com resultado de 1 teste aprovado.